### PR TITLE
プロジェクト整備: README・gitignore・ライセンス・設定ファイル追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,275 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Windows
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# Linux
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Project specific
+# 一時ファイル・キャッシュ
+temp/
+tmp/
+cache/
+.cache/
+
+# 動画ファイル（テスト用以外）
+*.mp4
+*.mov
+*.avi
+*.mkv
+*.wmv
+*.flv
+*.webm
+!test_samples/*.mp4
+!test_samples/*.mov
+
+# 字幕ファイル（出力結果）
+*.srt
+*.ass
+*.vtt
+!test_samples/*.srt
+
+# CSVファイル（翻訳ワークフロー）
+subs/
+*.csv
+!test_samples/*.csv
+
+# プロジェクトファイル
+*.subproj
+
+# OCRモデルキャッシュ
+paddle_models/
+tesseract_models/
+.paddleocr/
+
+# ログファイル
+*.log
+logs/
+
+# 設定ファイル（個人情報含む）
+config.json
+settings.json
+api_keys.json
+.env.local
+
+# PyInstallerビルド出力
+build/
+dist/
+*.exe
+*.app
+*.AppImage
+*.dmg
+*.msi
+
+# 開発用テストファイル
+test_videos/
+test_outputs/
+sandbox/
+
+# OS固有のサムネイル
+Thumbs.db
+.DS_Store
+
+# バックアップファイル
+*.bak
+*.backup
+*.old
+
+# PaddleOCR関連
+inference/
+.paddle/
+
+# 翻訳API関連
+google_credentials.json
+deepl_api_key.txt
+
+# ユーザーデータ
+user_data/
+projects/
+exports/
+
+# テンポラリ
+*.tmp
+*.temp

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 VLog字幕ツール Development Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,235 @@
-# vlog-subs-tool
+# VLog字幕ツール
+
+🎬 VLOG動画から字幕を自動抽出・編集・翻訳・出力する非エンジニア向けデスクトップアプリケーション
+
+## 📋 概要
+
+VLog字幕ツールは、音声なしのVLOG動画に焼き付けられた日本語字幕（ハードサブ）を自動抽出し、編集・翻訳・多言語字幕出力を一貫して行うGUIアプリケーションです。
+
+### 🎯 主要機能
+
+- **📖 OCR字幕抽出**: PaddleOCR/Tesseractによる日本語字幕の自動認識
+- **✏️ 直感的編集**: Excel風テーブルでの字幕直接編集・プレビュー同期
+- **🌍 多言語翻訳**: Google Cloud Translation・DeepL API・CSV外部連携対応
+- **📁 SRT出力**: 日本語・多言語SRTファイルの一括生成
+- **🔍 品質管理**: 行長・表示時間・重複・時間矛盾の自動チェック
+
+## 🚀 クイックスタート
+
+### 必要環境
+
+- **OS**: Windows 10/11, macOS 10.15+, Linux (Ubuntu 20.04+)
+- **Python**: 3.8+ (開発・ソースコード実行時)
+- **RAM**: 4GB以上推奨
+- **ストレージ**: 2GB以上の空き容量
+
+### インストール
+
+#### 方法1: バイナリ版（推奨）
+```bash
+# リリースページからダウンロード
+# Windows: vlog-subs-tool.exe
+# macOS: VLog字幕ツール.app
+# Linux: vlog-subs-tool.AppImage
+```
+
+#### 方法2: ソースコードから実行
+```bash
+# リポジトリのクローン
+git clone https://github.com/your-username/vlog-subs-tool.git
+cd vlog-subs-tool
+
+# 依存関係のインストール
+pip install -r requirements.txt
+
+# アプリケーション起動
+python -m app.main
+```
+
+### 基本的な使い方
+
+1. **動画読み込み**: 「動画を開く」で対象ファイルを選択
+2. **字幕抽出**: 「自動抽出」ボタンでOCR実行
+3. **編集**: 右側テーブルで字幕内容・タイミングを直接編集
+4. **品質チェック**: 「QCチェック」で問題箇所を確認
+5. **出力**: 「SRT出力」で字幕ファイルを保存
+
+## 📖 詳細機能
+
+### OCR字幕抽出
+
+- **エンジン選択**: PaddleOCR（高精度）・Tesseract（軽量）
+- **抽出領域**: 自動検出・下段30%固定・手動矩形指定
+- **サンプリング**: 3-5fps設定による最適化
+- **後処理**: 類似度判定によるテキスト統合・最小表示時間保証
+
+### 編集・プレビュー機能
+
+- **双方向同期**: テーブル選択⇔動画シーク・リアルタイムハイライト
+- **字幕操作**: 分割・結合・並び替え・追加・削除
+- **区間ループ**: 字幕区間での繰り返し再生
+- **字幕オーバーレイ**: 動画上での字幕表示確認
+
+### 翻訳・多言語対応
+
+#### 内蔵API翻訳
+- **Google Cloud Translation v3**: プロジェクト・ロケーション・APIキー設定
+- **DeepL API**: APIキー・フォーマリティ設定
+
+#### CSV外部翻訳連携
+```csv
+# エクスポート形式
+字幕番号,開始時間,終了時間,原文(ja),翻訳文,翻訳ステータス,翻訳者コメント
+1,00:05.000,00:08.000,こんにちは,,未翻訳,
+```
+
+- **Google Apps Script連携**: UTF-8 BOM・設定JSON・手順書の自動生成
+- **手動翻訳サポート**: Excel・Numbers等での編集ガイド
+- **品質検証**: インポート時の妥当性チェック
+
+### QC（品質管理）チェック
+
+| チェック項目 | 説明 | 重要度 |
+|-------------|------|--------|
+| 行長チェック | 1行42文字制限 | 警告 |
+| 最大行数 | 最大2行制限 | 警告 |
+| 表示時間 | 1.2-10秒範囲 | 警告/情報 |
+| 時間重複 | 字幕間重複検出 | エラー |
+| 時間順序 | 開始≦終了検証 | エラー |
+| 空文字検出 | 空テキスト検出 | エラー |
+| 重複テキスト | 近接同一文字列 | 警告 |
+| 読み速度 | 20文字/秒制限 | 警告 |
+
+## 📁 出力ファイル
+
+### SRT字幕ファイル
+```
+video.ja.srt          # 日本語字幕
+video.en.srt          # 英語字幕
+video.zh.srt          # 中国語字幕
+video.ko.srt          # 韓国語字幕
+video.ar.srt          # アラビア語字幕
+```
+
+### CSV翻訳ワークフロー
+```
+subs/
+├── video_ja_export.csv           # 翻訳元データ
+├── video_en_template.csv         # 英語テンプレート
+├── video_translation_config.json # GAS用設定
+└── video_翻訳手順.md              # 手順書
+```
+
+### プロジェクトファイル
+```
+project.subproj       # プロジェクト保存（JSON形式）
+```
+
+## ⚙️ 設定・カスタマイズ
+
+### OCR設定
+- **サンプリングFPS**: 3-5fps（精度 vs 速度）
+- **OCRエンジン**: PaddleOCR（既定）・Tesseract（選択式）
+- **抽出領域**: 自動検出・下段30%・手動矩形
+
+### 出力設定
+- **ファイル名**: `{basename}.{lang}.srt` パターン
+- **エンコーディング**: UTF-8（BOMオプション）
+- **改行コード**: LF（Unix）・CRLF（Windows）選択
+
+### 翻訳設定
+- **Google Cloud Translation**: プロジェクトID・ロケーション・APIキー
+- **DeepL**: APIキー・フォーマリティ（default/more/less）
+- **整形**: 句読点改行・行長制限・RTL言語対応
+
+## 🛠️ 開発・ビルド
+
+### 開発環境セットアップ
+```bash
+# 開発用依存関係
+pip install -r requirements.txt
+
+# 開発サーバー起動
+python -m app.main
+
+# テスト実行
+python -m pytest tests/
+
+# リント
+python -m flake8 app/
+python -m mypy app/
+```
+
+### バイナリビルド
+```bash
+# Windows
+pyinstaller --onefile --windowed app/main.py
+
+# macOS
+pyinstaller --onefile --windowed --name "VLog字幕ツール" app/main.py
+
+# Linux
+pyinstaller --onefile app/main.py
+```
+
+## 📋 技術仕様
+
+### アーキテクチャ
+- **GUI**: PySide6 (Qt for Python)
+- **動画処理**: OpenCV + ffmpeg
+- **OCR**: PaddleOCR (日本語特化) / Tesseract (汎用)
+- **翻訳**: Google Cloud Translation v3 / DeepL API
+- **データ**: JSON (プロジェクト) / CSV (翻訳連携) / SRT (出力)
+
+### ディレクトリ構成
+```
+app/
+├── core/              # コアロジック
+│   ├── extractor/     # OCR抽出エンジン
+│   ├── format/        # SRT・CSV処理
+│   ├── qc/           # 品質管理
+│   └── models.py     # データモデル
+├── ui/               # GUI
+│   ├── views/        # 画面・ダイアログ
+│   └── main_window.py # メインウィンドウ
+└── main.py           # エントリーポイント
+```
+
+## 🤝 コントリビューション
+
+### バグレポート・機能要望
+- **Issues**: [GitHub Issues](https://github.com/your-username/vlog-subs-tool/issues)
+- **サポート**: OCR精度向上・翻訳API追加・UI改善のご提案歓迎
+
+### 開発参加
+1. **Fork** このリポジトリ
+2. **Feature branch** 作成 (`git checkout -b feature/amazing-feature`)
+3. **Commit** 変更 (`git commit -m 'Add amazing feature'`)
+4. **Push** to branch (`git push origin feature/amazing-feature`)
+5. **Pull Request** 作成
+
+### コーディング規約
+- **Python**: PEP 8準拠・型ヒント必須
+- **コミット**: Conventional Commits形式
+- **テスト**: pytest・カバレッジ80%以上
+
+## 📄 ライセンス
+
+このプロジェクトは [MIT License](LICENSE) のもとで公開されています。
+
+## 🙏 謝辞
+
+- **PaddleOCR**: 高精度日本語OCRエンジン
+- **Tesseract**: オープンソースOCRエンジン
+- **PySide6**: クロスプラットフォームGUIフレームワーク
+- **OpenCV**: 動画・画像処理ライブラリ
+
+## 📞 サポート・お問い合わせ
+
+- **ドキュメント**: [Wiki](https://github.com/your-username/vlog-subs-tool/wiki)
+- **FAQ**: [よくある質問](https://github.com/your-username/vlog-subs-tool/wiki/FAQ)
+- **Discussions**: [GitHub Discussions](https://github.com/your-username/vlog-subs-tool/discussions)
+
+---
+
+**VLog字幕ツール v1.0** - VLOG動画字幕処理の決定版 🎬✨

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,189 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vlog-subs-tool"
+version = "1.0.0"
+description = "VLOG動画から字幕を自動抽出・編集・翻訳・出力する非エンジニア向けデスクトップアプリケーション"
+authors = [
+    {name = "VLog字幕ツール Development Team", email = "dev@vlog-subs-tool.com"},
+]
+license = {text = "MIT"}
+readme = "README.md"
+requires-python = ">=3.8"
+keywords = ["subtitle", "ocr", "translation", "video", "srt", "gui", "desktop"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Text Processing :: Linguistic",
+    "Topic :: Scientific/Engineering :: Image Recognition",
+    "Environment :: X11 Applications :: Qt",
+    "Environment :: Win32 (MS Windows)",
+    "Environment :: MacOS X",
+]
+
+dependencies = [
+    "PySide6>=6.5.0",
+    "opencv-python>=4.8.0",
+    "ffmpeg-python>=0.2.0",
+    "paddlepaddle>=2.5.0",
+    "paddleocr>=2.7.0",
+    "pytesseract>=0.3.10",
+    "google-cloud-translate>=3.12.0",
+    "deepl>=1.12.0",
+    "pandas>=2.0.0",
+    "numpy>=1.24.0",
+    "python-bidi>=0.4.2",
+    "pysrt>=1.1.2",
+    "PyYAML>=6.0",
+    "Pillow>=10.0.0",
+    "loguru>=0.7.0",
+    "tqdm>=4.65.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "pytest-qt>=4.2.0",
+    "flake8>=5.0.0",
+    "mypy>=1.0.0",
+    "black>=23.0.0",
+    "isort>=5.12.0",
+    "pre-commit>=3.0.0",
+]
+build = [
+    "pyinstaller>=5.13.0",
+    "setuptools>=61.0",
+    "wheel>=0.38.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/your-username/vlog-subs-tool"
+Repository = "https://github.com/your-username/vlog-subs-tool.git"
+Issues = "https://github.com/your-username/vlog-subs-tool/issues"
+Documentation = "https://github.com/your-username/vlog-subs-tool/wiki"
+
+[project.scripts]
+vlog-subs-tool = "app.main:main"
+
+[project.gui-scripts]
+vlog-subs-tool-gui = "app.main:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["app*"]
+exclude = ["tests*", "build*", "dist*"]
+
+[tool.black]
+line-length = 100
+target-version = ['py38', 'py39', 'py310', 'py311']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+  | paddle_models
+  | tesseract_models
+)/
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 100
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+known_first_party = ["app"]
+
+[tool.mypy]
+python_version = "3.8"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+strict_equality = true
+
+[[tool.mypy.overrides]]
+module = [
+    "cv2.*",
+    "paddleocr.*",
+    "tesseract.*",
+    "ffmpeg.*",
+    "pysrt.*",
+    "bidi.*",
+]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra -q --strict-markers --cov=app --cov-report=term-missing --cov-report=html"
+testpaths = [
+    "tests",
+]
+python_files = [
+    "test_*.py",
+    "*_test.py",
+]
+python_classes = [
+    "Test*",
+]
+python_functions = [
+    "test_*",
+]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "integration: marks tests as integration tests",
+    "unit: marks tests as unit tests",
+    "gui: marks tests as GUI tests",
+    "ocr: marks tests that require OCR models",
+]
+
+[tool.coverage.run]
+source = ["app"]
+omit = [
+    "*/tests/*",
+    "*/test_*.py",
+    "*/__main__.py",
+    "*/main.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "if self.debug:",
+    "if settings.DEBUG",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if 0:",
+    "if __name__ == .__main__.:",
+    "class .*\\bProtocol\\):",
+    "@(abc\\.)?abstractmethod",
+]


### PR DESCRIPTION
## 追加内容
- **README.md**: 詳細な機能説明・インストール手順・技術仕様
- **.gitignore**: Python・OCR・動画・設定ファイルの除外設定
- **LICENSE**: MIT License
- **pyproject.toml**: モダンなPythonプロジェクト設定

## README.md特徴
- 🎬 機能概要・クイックスタート・詳細機能説明
- 📖 OCR・編集・翻訳・QCチェックの包括的ドキュメント
- 🛠️ 開発環境・ビルド手順・コントリビューションガイド
- 📋 技術仕様・アーキテクチャ・ディレクトリ構成

## .gitignore網羅対象
- Python標準（__pycache__・dist・build等）
- OS固有（.DS_Store・Thumbs.db等）
- 動画・字幕・CSVファイル（テスト用除く）
- OCRモデルキャッシュ・API認証情報
- PyInstallerビルド出力・ユーザーデータ