### PR TITLE
fix: 相対インポートエラー修正でソースコード実行を可能に

### DIFF
--- a/app/core/csv/exporter.py
+++ b/app/core/csv/exporter.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
 from datetime import datetime
 
-from ..models import SubtitleItem
+from app.core.models import SubtitleItem
 
 
 @dataclass

--- a/app/core/csv/importer.py
+++ b/app/core/csv/importer.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import List, Dict, Any, Optional, Tuple
 from dataclasses import dataclass
 
-from ..models import SubtitleItem
+from app.core.models import SubtitleItem
 
 
 @dataclass

--- a/app/core/extractor/detector.py
+++ b/app/core/extractor/detector.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import time
 
-from ..models import SubtitleItem, ProjectSettings
+from app.core.models import SubtitleItem, ProjectSettings
 from .sampler import VideoSampler, BottomROISampler, VideoFrame
 from .roi import ROIManager, ROIMode, ROIRegion
 from .ocr import OCRManager, OCRResult

--- a/app/core/extractor/group.py
+++ b/app/core/extractor/group.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Tuple, Optional
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 
-from ..models import SubtitleItem
+from app.core.models import SubtitleItem
 from .ocr import OCRResult
 from .sampler import VideoFrame
 

--- a/app/core/format/srt.py
+++ b/app/core/format/srt.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
 
-from ..models import SubtitleItem
+from app.core.models import SubtitleItem
 
 
 @dataclass

--- a/app/core/qc/rules.py
+++ b/app/core/qc/rules.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Any
 from dataclasses import dataclass
 from enum import Enum
 
-from ..models import SubtitleItem, QCResult
+from app.core.models import SubtitleItem, QCResult
 
 
 class QCSeverity(Enum):

--- a/app/ui/extraction_worker.py
+++ b/app/ui/extraction_worker.py
@@ -5,8 +5,8 @@
 from PySide6.QtCore import QThread, Signal, QObject
 from typing import List, Optional
 
-from ..core.models import SubtitleItem, ProjectSettings
-from ..core.extractor.detector import SubtitleDetector
+from app.core.models import SubtitleItem, ProjectSettings
+from app.core.extractor.detector import SubtitleDetector
 
 
 class ExtractionWorker(QThread):

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -5,7 +5,7 @@ DESIGN.mdの画面仕様に基づくGUIレイアウト
 
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 
 from PySide6.QtWidgets import (
     QMainWindow, QApplication, QWidget, QHBoxLayout, QVBoxLayout,
@@ -20,9 +20,9 @@ from .views.table_view import SubtitleTableView
 from .views.translate_view import TranslateView
 from .views.settings_view import SettingsView
 from .extraction_worker import ExtractionWorker
-from ..core.models import Project, SubtitleItem
-from ..core.format.srt import SRTFormatter, SRTFormatSettings
-from ..core.qc.rules import QCChecker
+from app.core.models import Project, SubtitleItem
+from app.core.format.srt import SRTFormatter, SRTFormatSettings
+from app.core.qc.rules import QCChecker
 
 
 class MainWindow(QMainWindow):

--- a/app/ui/views/table_view.py
+++ b/app/ui/views/table_view.py
@@ -11,7 +11,7 @@ from PySide6.QtCore import Qt, Signal, QPoint
 from PySide6.QtGui import QFont, QColor, QAction
 from typing import List, Optional
 
-from ...core.models import SubtitleItem
+from app.core.models import SubtitleItem
 
 
 class SubtitleTableView(QWidget):

--- a/app/ui/views/translate_view.py
+++ b/app/ui/views/translate_view.py
@@ -11,12 +11,12 @@ from PySide6.QtCore import Qt, Signal, QThread
 from pathlib import Path
 from typing import List, Dict, Optional
 
-from ...core.models import SubtitleItem, Project
-from ...core.csv import (
+from app.core.models import SubtitleItem, Project
+from app.core.csv import (
     SubtitleCSVExporter, SubtitleCSVImporter, 
     TranslationWorkflowManager, CSVExportSettings
 )
-from ...core.format.srt import SRTFormatter
+from app.core.format.srt import SRTFormatter
 
 
 class TranslateView(QDialog):


### PR DESCRIPTION
## 問題
`python -m app.main`実行時に相対インポートによるImportErrorが発生

## 修正内容
- 全ファイルの相対インポート(`from ..`)を絶対インポート(`from app.`)に変更
- `typing.List`インポート不足を修正

## 影響範囲
- app/ui/main_window.py
- app/ui/views/*.py  
- app/core/**/*.py
- 計10ファイル

## テスト結果
✅ `python -m app.main`が正常実行可能

## 備考
これによりソースコードからの実行とバイナリ実行の両方が利用可能