### PR TITLE
fix: ウイルス誤検知対策 - onedir形式配布とYAML修正

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -56,18 +56,19 @@ jobs:
         cd dist/linux
         tar -czf "vlog-subs-tool-linux.tar.gz" vlog-subs-tool/
         # READMEファイルを追加
-        echo "VLog字幕ツール Linux版
+        cat > README_Linux.txt << 'EOF'
+        VLog字幕ツール Linux版
 
-使用方法:
-1. tar.gzファイルを展開: tar -xzf vlog-subs-tool-linux.tar.gz
-2. 実行権限を付与: chmod +x vlog-subs-tool/vlog-subs-tool
-3. 実行: ./vlog-subs-tool/vlog-subs-tool
+        使用方法:
+        1. tar.gzファイルを展開: tar -xzf vlog-subs-tool-linux.tar.gz
+        2. 実行権限を付与: chmod +x vlog-subs-tool/vlog-subs-tool
+        3. 実行: ./vlog-subs-tool/vlog-subs-tool
 
-注意事項:
-- フォルダ内のファイルを削除しないでください
-- 実行ファイルのみを移動すると動作しません
-- Ubuntu 20.04+ または同等のディストリビューションが必要です
-" > README_Linux.txt
+        注意事項:
+        - フォルダ内のファイルを削除しないでください
+        - 実行ファイルのみを移動すると動作しません
+        - Ubuntu 20.04+ または同等のディストリビューションが必要です
+        EOF
         tar -czf "vlog-subs-tool-linux.tar.gz" README_Linux.txt
 
     - name: Upload Linux binary
@@ -105,17 +106,18 @@ jobs:
         cd dist/windows
         zip -r "vlog-subs-tool-windows.zip" vlog-subs-tool/
         # READMEファイルを追加
-        echo "VLog字幕ツール Windows版
+        cat > README_Windows.txt << 'EOF'
+        VLog字幕ツール Windows版
 
-使用方法:
-1. ZIPファイルを適当なフォルダに展開
-2. フォルダ内の vlog-subs-tool.exe をダブルクリックして実行
-3. Windows Defenderの警告が出た場合は「詳細情報」→「実行」をクリック
+        使用方法:
+        1. ZIPファイルを適当なフォルダに展開
+        2. フォルダ内の vlog-subs-tool.exe をダブルクリックして実行
+        3. Windows Defenderの警告が出た場合は「詳細情報」→「実行」をクリック
 
-注意事項:
-- フォルダ内のファイルを削除しないでください
-- 実行ファイルのみを移動すると動作しません
-" > README_Windows.txt
+        注意事項:
+        - フォルダ内のファイルを削除しないでください
+        - 実行ファイルのみを移動すると動作しません
+        EOF
         zip "vlog-subs-tool-windows.zip" README_Windows.txt
 
     - name: Upload Windows binary
@@ -161,19 +163,20 @@ jobs:
         cd dist/macos
         zip -r "vlog-subs-tool-macos.zip" "VLog字幕ツール.app"
         # READMEファイルを追加
-        echo "VLog字幕ツール macOS版
+        cat > README_macOS.txt << 'EOF'
+        VLog字幕ツール macOS版
 
-使用方法:
-1. ZIPファイルを展開
-2. VLog字幕ツール.appをアプリケーションフォルダに移動（推奨）
-3. 右クリックで「開く」を選択（初回のみ）
-4. セキュリティ警告で「開く」をクリック
-5. 以降はダブルクリックで起動可能
+        使用方法:
+        1. ZIPファイルを展開
+        2. VLog字幕ツール.appをアプリケーションフォルダに移動（推奨）
+        3. 右クリックで「開く」を選択（初回のみ）
+        4. セキュリティ警告で「開く」をクリック
+        5. 以降はダブルクリックで起動可能
 
-注意事項:
-- .appファイルは単一のファイルです
-- macOS 10.15 (Catalina) 以上が必要です
-" > README_macOS.txt
+        注意事項:
+        - .appファイルは単一のファイルです
+        - macOS 10.15 (Catalina) 以上が必要です
+        EOF
         zip "vlog-subs-tool-macos.zip" README_macOS.txt
 
     - name: Upload macOS binary

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -69,7 +69,7 @@ jobs:
         - 実行ファイルのみを移動すると動作しません
         - Ubuntu 20.04+ または同等のディストリビューションが必要です
         EOF
-        tar -czf "vlog-subs-tool-linux.tar.gz" README_Linux.txt
+        tar -czf "vlog-subs-tool-linux.tar.gz" vlog-subs-tool/ README_Linux.txt
 
     - name: Upload Linux binary
       uses: actions/upload-artifact@v4
@@ -104,8 +104,7 @@ jobs:
     - name: Create Windows ZIP archive
       run: |
         cd dist/windows
-        zip -r "vlog-subs-tool-windows.zip" vlog-subs-tool/
-        # READMEファイルを追加
+        # READMEファイルを作成
         cat > README_Windows.txt << 'EOF'
         VLog字幕ツール Windows版
 
@@ -118,7 +117,7 @@ jobs:
         - フォルダ内のファイルを削除しないでください
         - 実行ファイルのみを移動すると動作しません
         EOF
-        zip "vlog-subs-tool-windows.zip" README_Windows.txt
+        zip -r "vlog-subs-tool-windows.zip" vlog-subs-tool/ README_Windows.txt
 
     - name: Upload Windows binary
       uses: actions/upload-artifact@v4
@@ -161,8 +160,7 @@ jobs:
     - name: Create macOS ZIP archive
       run: |
         cd dist/macos
-        zip -r "vlog-subs-tool-macos.zip" "VLog字幕ツール.app"
-        # READMEファイルを追加
+        # READMEファイルを作成
         cat > README_macOS.txt << 'EOF'
         VLog字幕ツール macOS版
 
@@ -177,7 +175,7 @@ jobs:
         - .appファイルは単一のファイルです
         - macOS 10.15 (Catalina) 以上が必要です
         EOF
-        zip "vlog-subs-tool-macos.zip" README_macOS.txt
+        zip -r "vlog-subs-tool-macos.zip" "VLog字幕ツール.app" README_macOS.txt
 
     - name: Upload macOS binary
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- PyInstallerの--onefileから--onedir形式に変更してウイルス誤検知を回避
- GitHub ActionsワークフローのYAML構文エラーを修正
- ZIP/tar.gzアーカイブでの配布形式に変更

## Changes
- `vlog-subs-tool.spec`: --onedir形式、UPX無効化
- `vlog-subs-tool-macos.spec`: macOS用.appバンドル、セキュリティ設定追加
- `scripts/build_binary.sh`: spec file優先使用に変更
- `.github/workflows/build-binaries.yml`: YAML構文修正、アーカイブ作成プロセス改善

## Test plan
- [x] GitHub Actionsワークフローが正常実行されること
- [x] Linux/Windows/macOS用バイナリが正しくビルドされること
- [x] アーカイブファイルが適切なREADMEと共に作成されること
- [ ] ウイルス検知率の改善確認