### PR TITLE
Fix: Windows環境でのPowerShell HereDoc構文エラーを修正

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -52,23 +52,24 @@ jobs:
         ./scripts/build_binary.sh linux
     
     - name: Create Linux archive
+      shell: bash
       run: |
         cd dist/linux
         tar -czf "vlog-subs-tool-linux.tar.gz" vlog-subs-tool/
         # READMEファイルを追加
         cat > README_Linux.txt << 'EOF'
-        VLog字幕ツール Linux版
+VLog字幕ツール Linux版
 
-        使用方法:
-        1. tar.gzファイルを展開: tar -xzf vlog-subs-tool-linux.tar.gz
-        2. 実行権限を付与: chmod +x vlog-subs-tool/vlog-subs-tool
-        3. 実行: ./vlog-subs-tool/vlog-subs-tool
+使用方法:
+1. tar.gzファイルを展開: tar -xzf vlog-subs-tool-linux.tar.gz
+2. 実行権限を付与: chmod +x vlog-subs-tool/vlog-subs-tool
+3. 実行: ./vlog-subs-tool/vlog-subs-tool
 
-        注意事項:
-        - フォルダ内のファイルを削除しないでください
-        - 実行ファイルのみを移動すると動作しません
-        - Ubuntu 20.04+ または同等のディストリビューションが必要です
-        EOF
+注意事項:
+- フォルダ内のファイルを削除しないでください
+- 実行ファイルのみを移動すると動作しません
+- Ubuntu 20.04+ または同等のディストリビューションが必要です
+EOF
         tar -czf "vlog-subs-tool-linux.tar.gz" vlog-subs-tool/ README_Linux.txt
 
     - name: Upload Linux binary
@@ -102,21 +103,22 @@ jobs:
         ./scripts/build_binary.sh windows
     
     - name: Create Windows ZIP archive
+      shell: bash
       run: |
         cd dist/windows
         # READMEファイルを作成
         cat > README_Windows.txt << 'EOF'
-        VLog字幕ツール Windows版
+VLog字幕ツール Windows版
 
-        使用方法:
-        1. ZIPファイルを適当なフォルダに展開
-        2. フォルダ内の vlog-subs-tool.exe をダブルクリックして実行
-        3. Windows Defenderの警告が出た場合は「詳細情報」→「実行」をクリック
+使用方法:
+1. ZIPファイルを適当なフォルダに展開
+2. フォルダ内の vlog-subs-tool.exe をダブルクリックして実行
+3. Windows Defenderの警告が出た場合は「詳細情報」→「実行」をクリック
 
-        注意事項:
-        - フォルダ内のファイルを削除しないでください
-        - 実行ファイルのみを移動すると動作しません
-        EOF
+注意事項:
+- フォルダ内のファイルを削除しないでください
+- 実行ファイルのみを移動すると動作しません
+EOF
         zip -r "vlog-subs-tool-windows.zip" vlog-subs-tool/ README_Windows.txt
 
     - name: Upload Windows binary
@@ -158,23 +160,24 @@ jobs:
         fi
     
     - name: Create macOS ZIP archive
+      shell: bash
       run: |
         cd dist/macos
         # READMEファイルを作成
         cat > README_macOS.txt << 'EOF'
-        VLog字幕ツール macOS版
+VLog字幕ツール macOS版
 
-        使用方法:
-        1. ZIPファイルを展開
-        2. VLog字幕ツール.appをアプリケーションフォルダに移動（推奨）
-        3. 右クリックで「開く」を選択（初回のみ）
-        4. セキュリティ警告で「開く」をクリック
-        5. 以降はダブルクリックで起動可能
+使用方法:
+1. ZIPファイルを展開
+2. VLog字幕ツール.appをアプリケーションフォルダに移動（推奨）
+3. 右クリックで「開く」を選択（初回のみ）
+4. セキュリティ警告で「開く」をクリック
+5. 以降はダブルクリックで起動可能
 
-        注意事項:
-        - .appファイルは単一のファイルです
-        - macOS 10.15 (Catalina) 以上が必要です
-        EOF
+注意事項:
+- .appファイルは単一のファイルです
+- macOS 10.15 (Catalina) 以上が必要です
+EOF
         zip -r "vlog-subs-tool-macos.zip" "VLog字幕ツール.app" README_macOS.txt
 
     - name: Upload macOS binary


### PR DESCRIPTION
## 概要
Issue #34で報告されたWindows環境でのビルドエラーを修正しました。PowerShellがBashのHereDoc構文を認識できずにビルドが失敗していた問題を解決しています。

## 🐛 修正した問題
### エラー内容
```
ParserError: Missing file specification after redirection operator.
```

Windows GitHub Actions環境で`<< 'EOF'`構文がPowerShellによって正しく解析されず、README生成ステップでビルドが失敗していました。

## 🔧 修正内容

### 1. Shell指定の明示化
すべてのアーカイブ作成ステップで`shell: bash`を明示的に指定し、Windows環境でもGit Bashが確実に使用されるようにしました。

```yaml
# 修正前
- name: Create Windows ZIP archive
  run: |

# 修正後  
- name: Create Windows ZIP archive
  shell: bash
  run: |
```

### 2. HereDoc構文の整理
HereDoc内容のインデントを調整し、一貫性のある記述形式に統一しました。

### 3. クロスプラットフォーム対応
Linux、Windows、macOS全環境でshell設定を統一し、各OSでの動作安定性を向上させました。

## 📁 変更ファイル
- `.github/workflows/build-binaries.yml`
  - `Create Windows ZIP archive`ステップの修正
  - `Create Linux archive`ステップの統一
  - `Create macOS ZIP archive`ステップの統一

## 🧪 期待される効果
- [x] Windows環境でのREADMEファイル正常生成
- [x] PowerShell環境での構文エラー解消
- [x] Windows向けZIPアーカイブの正常作成
- [x] リリース時のWindows版バイナリ配布

## 🔍 テスト方針
このPRがマージされると、次回のタグプッシュ時に以下が検証されます：
1. Windows環境でのビルドプロセス完了
2. README_Windows.txtの正常生成
3. vlog-subs-tool-windows.zipの作成
4. アーティファクトのアップロード成功

## 🎯 解決するIssue
Fixes #34

## 📋 チェックリスト
- [x] PowerShell互換性問題の特定と修正
- [x] shell設定の明示化
- [x] 全OS環境での一貫性確保
- [x] HereDoc構文の整理
- [x] コミットメッセージの詳細記述

## 🚀 次のステップ
この修正により、Windows向けバイナリが正常に生成され、ユーザーがすべてのプラットフォーム向けのリリースファイルをダウンロードできるようになります。

## 💡 技術詳細
- **根本原因**: Windows GitHub ActionsランナーがPowerShell 7をデフォルトで使用
- **解決方法**: `shell: bash`指定でGit Bashを強制使用
- **影響範囲**: アーカイブ作成ステップのみ（ビルド処理は影響なし）