### PR TITLE
Fix: Git ZIPダウンロード時のModuleNotFoundError問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,70 @@ python -m pytest tests/unit/test_models.py -v
 4. **品質チェック**: 「QCチェック」で問題箇所を確認
 5. **出力**: 「SRT出力」で字幕ファイルを保存
 
+## 🚨 トラブルシューティング
+
+### よくある問題と解決方法
+
+#### 🐛 「ModuleNotFoundError: No module named 'ui'」エラー
+
+**症状**: GitHubからZIPをダウンロードして直接実行すると以下のエラーが発生
+```
+Traceback (most recent call last):
+  File "main.py", line 16, in <module>
+ModuleNotFoundError: No module named 'ui'
+```
+
+**解決方法**:
+```bash
+# 1. 依存関係をインストール
+pip install -e .
+
+# 2. 推奨実行方法で起動
+python -m app.main
+```
+
+**Windows環境の場合**:
+```cmd
+# コマンドプロンプトまたはPowerShellで実行
+cd vlog-subs-tool-main
+pip install -e .
+python -m app.main
+```
+
+#### 🐛 「ImportError: No module named 'PySide6'」エラー
+
+**原因**: PySide6やその他の依存パッケージがインストールされていない
+
+**解決方法**:
+```bash
+# 仮想環境を作成（推奨）
+python -m venv venv
+source venv/bin/activate  # Linux/macOS
+# venv\Scripts\activate   # Windows
+
+# 依存関係をインストール
+pip install -e .
+```
+
+#### 🐛 Linux環境での日本語文字化け
+
+**解決方法**:
+```bash
+# 日本語フォントをインストール
+sudo apt install fonts-noto-cjk fonts-noto-cjk-extra  # Ubuntu/Debian
+sudo yum install google-noto-cjk-fonts                # CentOS/RHEL
+
+# ロケール設定（オプション）
+export LANG=ja_JP.UTF-8
+export LC_ALL=ja_JP.UTF-8
+```
+
+#### 📋 実行方法の優先順位
+
+1. **推奨**: `python -m app.main` （プロジェクトルートから）
+2. **次善**: `python app/main.py` （プロジェクトルートから）
+3. **非推奨**: `cd app && python main.py` （エラーの原因となりやすい）
+
 ## 📖 詳細機能
 
 ### OCR字幕抽出

--- a/app/main.py
+++ b/app/main.py
@@ -13,5 +13,41 @@ sys.path.insert(0, str(app_dir))
 
 # PySide6アプリケーション起動
 if __name__ == "__main__":
-    from ui.main_window import main
-    main()
+    try:
+        from ui.main_window import main
+        main()
+    except ModuleNotFoundError as e:
+        print("❌ エラー: 依存関係が不足しているか、実行方法に問題があります")
+        print()
+        print("🔧 解決方法:")
+        print("1. 依存関係をインストール:")
+        print("   pip install -e .")
+        print()
+        print("2. 推奨実行方法:")
+        print("   python -m app.main")
+        print()
+        print("3. または、プロジェクトルートから:")
+        print("   python app/main.py")
+        print()
+        print("📋 詳細なインストール手順:")
+        print("   https://github.com/lancelot89/vlog-subs-tool#インストール")
+        print()
+        print(f"🐛 元のエラー: {e}")
+        sys.exit(1)
+    except ImportError as e:
+        print("❌ エラー: 必要なパッケージがインストールされていません")
+        print()
+        print("🔧 解決方法:")
+        print("1. 仮想環境を作成 (推奨):")
+        print("   python -m venv venv")
+        print("   source venv/bin/activate  # Linux/macOS")
+        print("   # venv\\Scripts\\activate   # Windows")
+        print()
+        print("2. 依存関係をインストール:")
+        print("   pip install -e .")
+        print()
+        print("3. アプリケーションを起動:")
+        print("   python -m app.main")
+        print()
+        print(f"🐛 元のエラー: {e}")
+        sys.exit(1)


### PR DESCRIPTION
## 📋 概要

Issue #38 で報告されたGitHubからZIPファイルをダウンロードして直接実行した際の`ModuleNotFoundError: No module named 'ui'`エラーを修正します。

## 🔧 修正内容

### 1. app/main.py のエラーハンドリング強化
- **ModuleNotFoundError捕捉**: 依存関係不足時の分かりやすいエラーメッセージ
- **ImportError捕捉**: PySide6等のパッケージ未インストール時の対応
- **詳細な解決方法提示**: 具体的なコマンドとステップを表示
- **GitHub READMEへのリンク**: より詳しい手順への誘導

### 2. README.md トラブルシューティングセクション追加
- **よくある問題と解決方法**: ModuleNotFoundError、ImportErrorの対応
- **Windows環境特化手順**: コマンドプロンプト/PowerShell向けの説明
- **Linux環境文字化け対応**: 既存の対応策を整理
- **実行方法の優先順位**: 推奨・次善・非推奨の明確化

## 🎯 修正前後の動作

### 修正前
```
Traceback (most recent call last):
  File "main.py", line 16, in <module>
ModuleNotFoundError: No module named 'ui'
```

### 修正後
```
❌ エラー: 依存関係が不足しているか、実行方法に問題があります

🔧 解決方法:
1. 依存関係をインストール:
   pip install -e .

2. 推奨実行方法:
   python -m app.main

3. または、プロジェクトルートから:
   python app/main.py

📋 詳細なインストール手順:
   https://github.com/lancelot89/vlog-subs-tool#インストール

🐛 元のエラー: No module named 'ui'
```

## 🧪 テスト項目

- [ ] GitHubからZIPダウンロード → 依存関係未インストール状態での実行
- [ ] エラーメッセージの表示確認
- [ ] 推奨手順での正常動作確認
- [ ] Windows/Linux環境での動作確認

## 📚 関連

- Closes #38
- ユーザビリティ改善の一環
- v1.0.5リリース準備