### PR TITLE
feat: 自動抽出開始前の確認ダイアログを追加

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -639,6 +639,10 @@ class MainWindow(QMainWindow):
         if not self.check_ocr_setup():
             return
 
+        # 抽出開始前の確認ダイアログ
+        if not self._confirm_extraction_start():
+            return
+
         # 既存の抽出処理を停止
         self.stop_extraction()
 
@@ -695,6 +699,59 @@ class MainWindow(QMainWindow):
 
             # ワーカーにキャンセル要請
             self.extraction_worker.cancel()
+
+    def _confirm_extraction_start(self) -> bool:
+        """抽出開始前の確認ダイアログ"""
+        try:
+            # 動画情報を取得して処理時間を推定
+            video_path = self.current_project.source_video
+            import cv2
+            cap = cv2.VideoCapture(video_path)
+
+            if cap.isOpened():
+                fps = cap.get(cv2.CAP_PROP_FPS) or 30
+                frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+                duration = frame_count / fps if fps > 0 else 0
+                cap.release()
+
+                # 処理時間の目安を計算（概算）
+                estimated_minutes = max(1, int(duration / 60 * 0.5))  # 動画時間の約50%
+
+                duration_str = f"{int(duration // 60)}分{int(duration % 60)}秒"
+                estimated_str = f"約{estimated_minutes}分"
+            else:
+                duration_str = "不明"
+                estimated_str = "数分"
+
+        except Exception:
+            duration_str = "不明"
+            estimated_str = "数分"
+
+        # 確認ダイアログを表示
+        message = f"""字幕の自動抽出を開始しますか？
+
+📹 動画時間: {duration_str}
+⏱️ 予想処理時間: {estimated_str}
+
+📋 処理内容:
+• 動画フレームの解析
+• OCRによる文字認識
+• 字幕のグルーピング
+
+⚠️ 注意:
+• 処理中はアプリケーションが専有されます
+• 長時間の動画では時間がかかる場合があります
+• いつでもキャンセルボタンで中止できます"""
+
+        reply = QMessageBox.question(
+            self,
+            "字幕抽出の開始確認",
+            message,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.Yes
+        )
+
+        return reply == QMessageBox.Yes
 
     def check_ocr_setup(self) -> bool:
         """OCRセットアップの確認（組み込みモデル優先）"""


### PR DESCRIPTION
## 概要
Closes #68

自動抽出開始ボタンクリック時に確認ダイアログを表示するようにしました。

## 追加機能

### 1. 抽出開始前の確認ダイアログ
- 動画時間と予想処理時間を表示
- 処理内容の詳細説明
- 注意事項とキャンセル可能性を明示

### 2. インテリジェントな処理時間推定
- OpenCVで動画の実際の時間を取得
- 動画時間の約50%として処理時間を推定
- エラー時は「数分」として安全にフォールバック

### 3. ユーザーフレンドリーな表示
- 絵文字を使った見やすいレイアウト
- 処理内容の明確な説明
- 注意事項の適切な提示

## 表示例
```
字幕の自動抽出を開始しますか？

📹 動画時間: 10分30秒
⏱️ 予想処理時間: 約5分

📋 処理内容:
• 動画フレームの解析
• OCRによる文字認識
• 字幕のグルーピング

⚠️ 注意:
• 処理中はアプリケーションが専有されます
• 長時間の動画では時間がかかる場合があります
• いつでもキャンセルボタンで中止できます

[はい] [いいえ]
```

## 改善効果
- 意図しない長時間処理の開始を防止
- 処理時間の目安でユーザーが判断可能
- 処理内容の理解促進
- より安心して機能を利用可能

## 動作確認
- [ ] 自動抽出ボタンクリック時に確認ダイアログが表示される
- [ ] 動画時間と処理時間が正しく表示される
- [ ] 「はい」選択で抽出が開始される
- [ ] 「いいえ」選択で処理がキャンセルされる

## 影響範囲
- `start_extraction()`メソッドの開始フローのみ
- 既存機能には影響なし
- ユーザーエクスペリエンスの向上