### PR TITLE
OCR簡素化後の構文エラーを修正

### DIFF
--- a/app/ui/dialogs/ocr_setup_dialog.py
+++ b/app/ui/dialogs/ocr_setup_dialog.py
@@ -166,8 +166,8 @@ class OCRSetupDialog(QDialog):
             # PaddleOCRエンジンが利用できない場合
             self.status_label.setText("❌ PaddleOCRエンジンが利用できません")
             self.status_label.setStyleSheet("color: red;")
-                self.setup_btn.setEnabled(False)
-                self.add_log("利用可能なOCRエンジンが見つかりません")
+            self.setup_btn.setEnabled(False)
+            self.add_log("利用可能なOCRエンジンが見つかりません")
 
         except Exception as e:
             self.status_label.setText(f"❌ エラー: {str(e)}")


### PR DESCRIPTION
## Summary
Closes #81

OCR処理の簡素化（PR #80）をマージした後に発生していた構文エラーを修正しました。

### 問題
- `ocr_setup_dialog.py`の169行目でインデントエラー（unexpected indent）が発生
- アプリケーションが起動できない状態

### 修正内容
- 169-170行目のインデントを正しく調整
- OCR簡素化時の編集ミスによる不適切なインデントを修正

### 動作確認
- ✅ 構文エラーが解消されることを確認
- ✅ アプリケーションが正常に起動することを確認  
- ✅ 段階的インポートテストがすべて通過することを確認

## Test plan
- [x] 構文エラーが修正されている
- [x] アプリケーションが正常に起動する
- [x] OCRセットアップダイアログがインポートできる

🤖 Generated with [Claude Code](https://claude.ai/code)