### PR TITLE
SimplePaddleOCREngine初期化パラメータを修正してOCRセットアップダイアログの不要表示を解消

### DIFF
--- a/app/core/extractor/ocr.py
+++ b/app/core/extractor/ocr.py
@@ -107,10 +107,6 @@ class SimplePaddleOCREngine:
                 "rec_model_dir": str(rec_dir),
                 "lang": lang,
                 "use_angle_cls": True,
-                "use_gpu": False,
-                "show_log": False,
-                "use_space_char": True,
-                "drop_score": 0.5,
             }
 
             logging.debug(f"PaddleOCR init kwargs: {kwargs}")


### PR DESCRIPTION
## Summary
Closes #83

SimplePaddleOCREngineの初期化で使用されていた非対応パラメータが原因で、OCRエンジンの初期化に失敗し、不要にOCRセットアップダイアログが表示される問題を修正しました。

### 問題の詳細
- SimplePaddleOCREngineが組み込みモデルを使用できるにも関わらず、初期化に失敗していた
- 原因：PaddleOCRでサポートされていない以下のパラメータを使用していた：
  - `drop_score`
  - `use_space_char` 
  - `use_gpu`
  - `show_log`

### 修正内容
- PaddleOCRでサポートされている最小限のパラメータのみに変更
- 以下のパラメータのみ使用するよう修正：
  - `det_model_dir`
  - `rec_model_dir`
  - `lang`
  - `use_angle_cls`

### 動作確認
- ✅ SimplePaddleOCREngineの初期化が成功することを確認
- ✅ アプリケーション起動時にOCRセットアップダイアログが表示されないことを確認
- ✅ アプリケーションが正常に起動することを確認

## Test plan
- [x] SimplePaddleOCREngineが正常に初期化される
- [x] OCRセットアップダイアログが不要に表示されない
- [x] アプリケーションが即座に字幕抽出を開始できる状態になる

🤖 Generated with [Claude Code](https://claude.ai/code)