### PR TITLE
fix: Windows環境でPaddleOCR初期化失敗時の適切なエラー表示 (#91)

### DIFF
--- a/app/core/extractor/ocr.py
+++ b/app/core/extractor/ocr.py
@@ -191,8 +191,20 @@ class SimplePaddleOCREngine:
                 combined_errors = "; ".join(error_messages)
                 raise Exception(f"All PaddleOCR configurations failed: {combined_errors}")
             return True
+        except FileNotFoundError as e:
+            logging.error(f"PaddleOCR model files not found on {platform.system()}: {e}")
+            self._ocr = None
+            return False
+        except ImportError as e:
+            logging.error(f"PaddleOCR import error on {platform.system()}: {e}")
+            self._ocr = None
+            return False
         except Exception as e:
             logging.error(f"PaddleOCR initialization failed on {platform.system()}: {e}")
+            logging.error(f"Error type: {type(e).__name__}")
+            if hasattr(e, '__traceback__'):
+                import traceback
+                logging.error(f"Traceback: {traceback.format_exc()}")
             self._ocr = None
             return False
 

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -891,35 +891,37 @@ class MainWindow(QMainWindow):
 
     def check_ocr_setup(self) -> bool:
         """OCRセットアップの確認（SimplePaddleOCREngine使用）"""
-        # SimplePaddleOCREngineの利用可能性をチェック
-        ocr_engine = SimplePaddleOCREngine()
+        try:
+            # SimplePaddleOCREngineの利用可能性をチェック
+            ocr_engine = SimplePaddleOCREngine()
 
-        if ocr_engine.initialize():
-            logging.info("SimplePaddleOCREngineを使用して字幕抽出を開始します")
-            self.status_label.setText("PaddleOCRエンジンで字幕抽出を開始...")
-            return True
+            if ocr_engine.initialize():
+                logging.info("SimplePaddleOCREngineを使用して字幕抽出を開始します")
+                self.status_label.setText("PaddleOCRエンジンで字幕抽出を開始...")
+                return True
+            else:
+                # 初期化失敗時の詳細メッセージ
+                QMessageBox.critical(
+                    self,
+                    "PaddleOCR初期化エラー",
+                    "PaddleOCRエンジンの初期化に失敗しました。\n\n"
+                    "考えられる原因：\n"
+                    "• モデルファイルが見つからない\n"
+                    "• PaddleOCRライブラリの問題\n"
+                    "• メモリ不足\n"
+                    "• 依存関係の問題\n\n"
+                    "ログを確認してください。"
+                )
+                return False
 
-        # 利用可能なエンジンがない場合のみセットアップダイアログを表示
-        logging.warning("利用可能なOCRエンジンが見つかりません。セットアップダイアログを表示します。")
-
-        # セットアップダイアログを表示
-        setup_dialog = OCRSetupDialog(self)
-        result = setup_dialog.exec()
-
-        if result == setup_dialog.Accepted:
-            # セットアップ完了
-            self.status_label.setText("OCRセットアップが完了しました")
-            return True
-        else:
-            # セットアップをキャンセル
-            QMessageBox.warning(
+        except Exception as e:
+            # 予期しないエラーの場合
+            logging.error(f"OCRセットアップ確認中にエラー: {e}")
+            QMessageBox.critical(
                 self,
-                "警告",
-                "OCRエンジンが利用できません。\n\n"
-                "字幕抽出を行うには以下のいずれかが必要です：\n"
-                "• PaddleOCRのセットアップ\n"
-                "• Tesseractのインストール\n\n"
-                "設定画面からOCRエンジンを設定してください。"
+                "OCRセットアップエラー",
+                f"OCRエンジンの確認中にエラーが発生しました：\n{str(e)}\n\n"
+                "アプリケーションを再起動してお試しください。"
             )
             return False
     


### PR DESCRIPTION
## Summary
Windows環境で自動抽出ボタンを押した際にセットアップダイアログが表示される問題を修正し、LinuxとWindowsで統一された動作を実現します。

## 変更内容

### 🔧 main_window.py: check_ocr_setup()メソッドの改善
- PaddleOCR初期化失敗時にセットアップダイアログではなく具体的なエラーメッセージを表示
- try-catch構文でエラーハンドリングを強化
- ユーザーに分かりやすい原因と対処法を提示

### 🔧 ocr.py: SimplePaddleOCREngine.initialize()の詳細ログ強化  
- FileNotFoundError、ImportErrorを個別にキャッチ
- エラー種別とトレースバック情報の出力
- Windows固有の問題の特定を容易にする

## 動作確認

### Before（修正前）
- **Linux**: 自動抽出ボタン → 確認ダイアログ → 抽出実行
- **Windows**: 自動抽出ボタン → OCRセットアップダイアログ表示

### After（修正後）  
- **Linux**: 従来通りの正常動作を維持
- **Windows**: 自動抽出ボタン → 初期化エラーの具体的メッセージ表示

## Test plan
- [ ] Linux環境で既存の動作が維持されることを確認
- [ ] Windows環境で初期化失敗時に適切なエラーメッセージが表示されることを確認
- [ ] ログ出力が詳細化されていることを確認
- [ ] 両環境でユーザビリティが向上していることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)