### PR TITLE
fix: numpy互換性エラーを修正

### DIFF
--- a/app/core/extractor/ocr.py
+++ b/app/core/extractor/ocr.py
@@ -444,7 +444,7 @@ class SimplePaddleOCREngine:
         elif processed.ndim != 3:
             return None
 
-        if not processed.flags.get("C_CONTIGUOUS", False):
+        if not processed.flags.c_contiguous:
             processed = np.ascontiguousarray(processed)
 
         height, width = processed.shape[:2]


### PR DESCRIPTION
## Summary
- `processed.flags.get("C_CONTIGUOUS", False)` を `processed.flags.c_contiguous` に変更
- 新しいnumpyバージョンでflagsオブジェクトがgetメソッドを持たなくなった問題を解決
- OCR処理での`'numpy.core.multiarray.flagsobj' object has no attribute 'get'`エラーを修正

## Background
Windows環境でPaddleOCR使用時にnumpy互換性エラーが発生していました。numpy 2.x系ではflagsオブジェクトのAPIが変更され、`.get()`メソッドが削除されました。

## Changes
- `app/core/extractor/ocr.py`の447行目を修正
- `processed.flags.get("C_CONTIGUOUS", False)` → `processed.flags.c_contiguous`

## Test plan
- [x] 既存のPaddleOCRテストが正常に動作することを確認
- [x] numpy 2.x環境でflagsオブジェクトエラーが発生しないことを確認
- [x] OCR処理が正常に実行されることを確認

Closes #97