### PR TITLE
字幕選択後のブラックアウト問題を修正

### DIFF
--- a/app/ui/views/table_view.py
+++ b/app/ui/views/table_view.py
@@ -5,10 +5,10 @@
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QTableWidget,
     QTableWidgetItem, QHeaderView, QAbstractItemView, QMenu,
-    QMessageBox, QInputDialog
+    QMessageBox, QInputDialog, QApplication
 )
 from PySide6.QtCore import Qt, Signal, QPoint
-from PySide6.QtGui import QFont, QColor, QAction
+from PySide6.QtGui import QFont, QColor, QAction, QPalette
 from typing import List, Optional
 
 from app.core.models import SubtitleItem
@@ -267,7 +267,9 @@ class SubtitleTableView(QWidget):
             for col in range(self.table.columnCount()):
                 item = self.table.item(self.current_highlight_row, col)
                 if item:
-                    item.setBackground(QColor())
+                    # システムのデフォルト背景色に戻す
+                    default_bg = QApplication.palette().color(QPalette.Base)
+                    item.setBackground(default_bg)
         
         # 現在時間に該当する字幕を検索
         current_row = -1

--- a/test_table_highlight.py
+++ b/test_table_highlight.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+字幕テーブルのハイライト機能テスト
+Issue #105: 抽出字幕を一度選択した場所がブラックアウトする問題の修正テスト
+"""
+
+import sys
+from pathlib import Path
+
+# アプリケーションのパスを追加
+sys.path.insert(0, str(Path(__file__).parent))
+
+from PySide6.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QWidget, QPushButton, QHBoxLayout
+from PySide6.QtCore import QTimer
+from app.ui.views.table_view import SubtitleTableView
+from app.core.models import SubtitleItem
+
+class TestWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("字幕テーブル ハイライトテスト")
+        self.setGeometry(100, 100, 800, 600)
+
+        # メインウィジェット
+        main_widget = QWidget()
+        self.setCentralWidget(main_widget)
+        layout = QVBoxLayout(main_widget)
+
+        # テスト用ボタン
+        button_layout = QHBoxLayout()
+
+        self.highlight_btn1 = QPushButton("字幕1をハイライト")
+        self.highlight_btn1.clicked.connect(lambda: self.table_view.highlight_current_subtitle(1000))
+        button_layout.addWidget(self.highlight_btn1)
+
+        self.highlight_btn2 = QPushButton("字幕2をハイライト")
+        self.highlight_btn2.clicked.connect(lambda: self.table_view.highlight_current_subtitle(3000))
+        button_layout.addWidget(self.highlight_btn2)
+
+        self.clear_btn = QPushButton("ハイライトクリア")
+        self.clear_btn.clicked.connect(lambda: self.table_view.highlight_current_subtitle(-1))
+        button_layout.addWidget(self.clear_btn)
+
+        layout.addLayout(button_layout)
+
+        # 字幕テーブル
+        self.table_view = SubtitleTableView()
+        layout.addWidget(self.table_view)
+
+        # テスト用字幕データを設定
+        self.setup_test_data()
+
+    def setup_test_data(self):
+        """テスト用の字幕データを設定"""
+        test_subtitles = [
+            SubtitleItem(index=1, start_ms=0, end_ms=2000, text="テスト字幕1"),
+            SubtitleItem(index=2, start_ms=2500, end_ms=4500, text="テスト字幕2"),
+            SubtitleItem(index=3, start_ms=5000, end_ms=7000, text="テスト字幕3"),
+            SubtitleItem(index=4, start_ms=7500, end_ms=9500, text="テスト字幕4"),
+        ]
+        self.table_view.set_subtitles(test_subtitles)
+
+def main():
+    app = QApplication(sys.argv)
+
+    window = TestWindow()
+    window.show()
+
+    sys.exit(app.exec())
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
字幕テーブルで一度選択した行が黒く表示される問題を修正しました。

## Changes
- [x] バグ修正 (fix)

## Background & Purpose
Issue #105で報告された、字幕テーブルで一度選択した場所がブラックアウトする問題の修正。

## Technical Details
### 問題の原因
- `SubtitleTableView.highlight_current_subtitle()`メソッドで
- ハイライトクリア時に`QColor()`を使用
- 空のQColorが黒色として表示される

### 修正内容
- システムのデフォルト背景色を使用するように変更
- `QApplication.palette().color(QPalette.Base)`で適切な背景色を取得
- ダークモード/ライトモード両方に対応

### 修正箇所
`app/ui/views/table_view.py:highlight_current_subtitle()`
```python
# 修正前
item.setBackground(QColor())

# 修正後  
default_bg = QApplication.palette().color(QPalette.Base)
item.setBackground(default_bg)
```

## Testing
### 動作確認
- [x] 主要機能テスト完了
- [x] エラーハンドリング確認
- [x] パフォーマンス影響なし

### テスト結果
- `test_table_highlight.py`でハイライト機能をテスト
- 字幕選択→ハイライトクリア→正常な背景色復元を確認

## Impact
### 互換性
- [x] 破壊的変更なし

### パフォーマンス
- [x] 影響なし

## Related Issues
Closes #105

## Notes
この修正により、字幕選択後も正常な背景色が維持され、ユーザビリティが向上します。