### PR TITLE
fix: 自動抽出ボタン押下時の確認ダイアログ表示遅延を改善

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -632,12 +632,12 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "警告", "動画ファイルが選択されていません。")
             return
 
-        # OCRセットアップ確認
-        if not self.check_ocr_setup():
+        # 抽出開始前の確認ダイアログ（先に表示）
+        if not self._confirm_extraction_start():
             return
 
-        # 抽出開始前の確認ダイアログ
-        if not self._confirm_extraction_start():
+        # OCRセットアップ確認（確認ダイアログの後に実行）
+        if not self.check_ocr_setup():
             return
 
         # 既存の抽出処理を停止
@@ -892,6 +892,11 @@ class MainWindow(QMainWindow):
     def check_ocr_setup(self) -> bool:
         """OCRセットアップの確認（SimplePaddleOCREngine使用）"""
         try:
+            # 初期化開始をユーザーに通知
+            self.status_label.setText("OCRエンジン初期化中...")
+            # UIの更新を強制実行
+            QApplication.processEvents()
+
             # SimplePaddleOCREngineの利用可能性をチェック
             ocr_engine = SimplePaddleOCREngine()
 


### PR DESCRIPTION
## Summary
Closes #119

自動抽出ボタンを押した際の確認ダイアログ表示の遅延を改善しました。

## 変更内容

### 問題
- 自動抽出ボタンを押すとOCR初期化処理（重い処理）が先に実行され、確認ダイアログの表示が遅かった

### 解決策
- **処理順序の変更**：確認ダイアログを先に表示し、ユーザーが「はい」を押した後にOCR初期化を実行
- **ユーザーフィードバックの追加**：OCR初期化中に「OCRエンジン初期化中...」メッセージを表示
- **UI応答性の向上**：`QApplication.processEvents()`でUI更新を強制実行

### 変更箇所
- `app/ui/main_window.py`: `start_extraction()`メソッドの処理順序を変更
- `app/ui/main_window.py`: `check_ocr_setup()`メソッドに初期化中メッセージを追加

## 変更前後の動作フロー

### 変更前（問題）
1. `start_extraction()` 呼び出し
2. **OCR初期化** (`check_ocr_setup()`) ← 重い処理で遅延発生
3. 確認ダイアログ (`_confirm_extraction_start()`)

### 変更後（改善）
1. `start_extraction()` 呼び出し  
2. **確認ダイアログ** (`_confirm_extraction_start()`) ← 瞬時表示
3. **OCR初期化** (`check_ocr_setup()`) + 初期化中メッセージ表示

## Test plan
- [x] 構文エラーチェック完了
- [x] 自動抽出ボタン押下時の確認ダイアログが瞬時に表示されることを確認
- [x] OCR初期化処理が確認ダイアログ後に実行されることを確認
- [x] 初期化中メッセージが適切に表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)