### PR TITLE
fix: CSV出力形式を改善

### DIFF
--- a/app/core/csv/exporter.py
+++ b/app/core/csv/exporter.py
@@ -127,20 +127,17 @@ class SubtitleCSVExporter:
     def _get_standard_headers(self) -> List[str]:
         """標準CSVヘッダーを取得"""
         headers = []
-        
+
         if self.settings.include_index:
             headers.append("字幕番号")
-        
+
         if self.settings.include_timing:
-            headers.extend(["開始時間(ms)", "終了時間(ms)", "表示時間(秒)"])
-        
+            headers.extend(["開始時間", "終了時間", "表示時間(秒)"])
+
         headers.extend([
-            "字幕テキスト",
-            "文字数",
-            "行数",
-            "作成日時"
+            "字幕テキスト"
         ])
-        
+
         return headers
     
     def _create_translation_row(self, subtitle: SubtitleItem, source_lang: str) -> List[str]:
@@ -169,28 +166,24 @@ class SubtitleCSVExporter:
     def _create_standard_row(self, subtitle: SubtitleItem) -> List[str]:
         """標準行データを作成"""
         row = []
-        
+
         if self.settings.include_index:
             row.append(str(subtitle.index))
-        
+
         if self.settings.include_timing:
+            start_time = self._format_time_for_csv(subtitle.start_ms)
+            end_time = self._format_time_for_csv(subtitle.end_ms)
             duration = (subtitle.end_ms - subtitle.start_ms) / 1000
             row.extend([
-                str(subtitle.start_ms),
-                str(subtitle.end_ms),
+                start_time,
+                end_time,
                 f"{duration:.1f}"
             ])
-        
-        char_count = len(subtitle.text.replace('\n', '').replace(' ', ''))
-        line_count = len(subtitle.text.split('\n'))
-        
+
         row.extend([
-            subtitle.text,
-            str(char_count),
-            str(line_count),
-            datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+            subtitle.text
         ])
-        
+
         return row
     
     def _format_time_for_csv(self, time_ms: int) -> str:


### PR DESCRIPTION
## Summary
Closes #125

CSV出力形式を改善し、より読みやすく簡潔な形式にしました。

## 変更内容

### 時間フォーマットの改善
- **変更前**: ミリ秒数値 (例: `11200`, `15800`)
- **変更後**: `MM:SS.mmm` 形式 (例: `00:11.200`, `00:15.800`)

### 不要な列の削除
- **削除された列**:
  - 文字数
  - 行数  
  - 作成日時

### 最終的なCSV形式
```csv
字幕番号,開始時間,終了時間,表示時間(秒),字幕テキスト
1,00:11.200,00:15.800,4.6,これはテスト字幕です
2,01:00.000,01:05.500,5.5,2番目の字幕です
```

## 変更箇所
- `app/core/csv/exporter.py`:
  - `_get_standard_headers()`: ヘッダーから不要な列を削除
  - `_create_standard_row()`: 時間フォーマットを`_format_time_for_csv()`使用に変更、不要な列を削除

## 技術的詳細
- 既存の`_format_time_for_csv()`メソッドを活用
- 翻訳用CSV形式は既に適切な形式だったため変更なし
- コード量削減: 22行削除、15行追加

## Test plan
- [x] CSV出力形式の単体テスト実行
- [x] 実際のCSVファイル出力確認
- [x] 時間フォーマット正確性検証
- [x] 期待通りの列構成確認

### テスト結果例
```csv
字幕番号,開始時間,終了時間,表示時間(秒),字幕テキスト
1,00:11.200,00:15.800,4.6,これはテスト字幕です
2,01:00.000,01:05.500,5.5,"2番目の字幕です
複数行のテスト"
3,02:05.500,02:08.000,2.5,最後の字幕です
```

🤖 Generated with [Claude Code](https://claude.ai/code)