### PR TITLE
fix: Windowsアプリ起動時の不要な警告メッセージを削除

### DIFF
--- a/app/core/extractor/ocr.py
+++ b/app/core/extractor/ocr.py
@@ -104,7 +104,7 @@ def _create_safe_paddleocr_kwargs(original: Mapping[str, Any]) -> Dict[str, Any]
         if key == "use_angle_cls":
             # PaddleOCR >= 3.0 renamed the flag to use_textline_orientation.
             safe["use_textline_orientation"] = bool(value)
-        elif key in {"show_log", "use_space_char", "use_gpu"}:
+        elif key in {"show_log", "use_space_char", "use_gpu", "max_text_length"}:
             # No longer accepted by the constructor – ignore silently.
             continue
         elif key == "drop_score":
@@ -351,7 +351,6 @@ class SimplePaddleOCREngine:
                         "use_space_char": True,
                         "drop_score": 0.5,
                         "enable_mkldnn": True,  # MKL-DNN有効化
-                        "max_text_length": 25,
                     } if use_aggressive else None,
                     # Phase 2: 中程度の最適化
                     {
@@ -363,7 +362,6 @@ class SimplePaddleOCREngine:
                         "use_space_char": True,
                         "drop_score": 0.5,
                         "enable_mkldnn": True,  # MKL-DNN有効化のみ
-                        "max_text_length": 25,
                     },
                     # Phase 3: 安全設定 (従来の設定)
                     {
@@ -375,7 +373,6 @@ class SimplePaddleOCREngine:
                         "use_space_char": True,
                         "drop_score": 0.5,
                         "enable_mkldnn": False,
-                        "max_text_length": 25,
                     },
                     # Phase 4: Legacy API fallback
                     {

--- a/app/core/translate/language_detector.py
+++ b/app/core/translate/language_detector.py
@@ -12,7 +12,7 @@ try:
     LANGDETECT_AVAILABLE = True
 except ImportError:
     LANGDETECT_AVAILABLE = False
-    logging.warning("langdetectが利用できません。pip install langdetectでインストールしてください。")
+    # langdetectは自動言語検出機能でのみ使用され、現在は無効化されているため警告を出力しない
 
 
 @dataclass

--- a/app/core/translate/provider_local.py
+++ b/app/core/translate/provider_local.py
@@ -17,14 +17,14 @@ try:
     CTRANSLATE2_AVAILABLE = True
 except ImportError:
     CTRANSLATE2_AVAILABLE = False
-    logging.warning("CTranslate2パッケージが利用できません。pip install ctranslate2 transformersでインストールしてください。")
+    # CTranslate2はローカル翻訳機能でのみ使用され、現在は無効化されているため警告を出力しない
 
 try:
     import opencc
     OPENCC_AVAILABLE = True
 except ImportError:
     OPENCC_AVAILABLE = False
-    logging.warning("OpenCCが利用できません。pip install opencc-python-reimplementedでインストールしてください。")
+    # OpenCCは中国語変換でのみ使用され、現在は無効化されているため警告を出力しない
 
 from .language_detector import LanguageDetector, LanguageDetectionError
 


### PR DESCRIPTION
## Summary
- Windows環境で`python -m app.main`実行時に出力される不要な警告メッセージを削除
- CTranslate2/OpenCC/langdetectのimport警告を抑制（これらは現在使用されていないため）
- PaddleOCRの`max_text_length`パラメータエラーを修正（新バージョンで非サポート）

## 修正内容
- `app/core/translate/provider_local.py`: CTranslate2とOpenCCのimport警告を削除
- `app/core/translate/language_detector.py`: langdetectのimport警告を削除  
- `app/core/extractor/ocr.py`: `max_text_length`パラメータを削除し、パラメータサニタイゼーション関数を更新

## 動作確認
- ✅ 警告メッセージが出力されないことを確認
- ✅ PaddleOCRパラメータが正しくサニタイズされることを確認
- ✅ アプリケーションが正常に起動することを確認

Closes #145