### PR TITLE
feat: ツールバーのUIを改善

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -271,17 +271,11 @@ class MainWindow(QMainWindow):
         
         toolbar.addSeparator()
         
-        # 自動抽出
-        self.extract_btn = QPushButton("自動抽出")
+        # 字幕抽出
+        self.extract_btn = QPushButton("字幕抽出")
         self.extract_btn.clicked.connect(self.start_extraction)
         self.extract_btn.setEnabled(False)
         toolbar.addWidget(self.extract_btn)
-        
-        # 再抽出
-        self.re_extract_btn = QPushButton("再抽出")
-        self.re_extract_btn.clicked.connect(self.re_extract)
-        self.re_extract_btn.setEnabled(False)
-        toolbar.addWidget(self.re_extract_btn)
 
         # 旧キャンセルボタン（下位互換のため残すが、使用は停止）
         self.cancel_btn = QPushButton("🛑 抽出停止")
@@ -289,14 +283,6 @@ class MainWindow(QMainWindow):
         self.cancel_btn.setVisible(False)  # 常に非表示
         # NOTE: 新しい実装では自動抽出ボタン自体がキャンセルボタンに変化するため、
         # この独立したキャンセルボタンは表示されません
-        
-        toolbar.addSeparator()
-        
-        # QCチェック
-        self.qc_btn = QPushButton("QCチェック")
-        self.qc_btn.clicked.connect(self.run_qc_check)
-        self.qc_btn.setEnabled(False)
-        toolbar.addWidget(self.qc_btn)
         
         toolbar.addSeparator()
         
@@ -314,13 +300,7 @@ class MainWindow(QMainWindow):
         self.csv_export_action = self.csv_export_btn
         
         toolbar.addSeparator()
-        
-        # 保存
-        self.save_btn = QPushButton("保存")
-        self.save_btn.clicked.connect(self.save_project)
-        self.save_btn.setEnabled(False)
-        toolbar.addWidget(self.save_btn)
-        
+
         # SRT出力
         self.export_srt_btn = QPushButton("SRT出力")
         self.export_srt_btn.clicked.connect(self.export_japanese_srt)
@@ -490,7 +470,6 @@ class MainWindow(QMainWindow):
 
             # UIの更新
             self.extract_btn.setEnabled(True)
-            self.save_btn.setEnabled(True)
 
             # ファイル情報の更新
             file_name = Path(file_path).name
@@ -583,8 +562,6 @@ class MainWindow(QMainWindow):
 
         # UI状態の更新
         self.extract_btn.setEnabled(True)
-        self.re_extract_btn.setEnabled(True)
-        self.qc_btn.setEnabled(True)
         self.translate_btn.setEnabled(True)
         self.csv_export_btn.setEnabled(True)
         if hasattr(self, 'csv_export_menu_action') and self.csv_export_menu_action is not None:
@@ -607,7 +584,6 @@ class MainWindow(QMainWindow):
 
         # UI状態をリセット
         self.extract_btn.setEnabled(True)
-        self.re_extract_btn.setEnabled(True)
         self.status_label.setText("字幕の抽出に失敗しました")
 
     def on_extraction_cancelled(self):
@@ -621,7 +597,6 @@ class MainWindow(QMainWindow):
 
         # UI状態をリセット
         self.extract_btn.setEnabled(True)
-        self.re_extract_btn.setEnabled(True)
         self.status_label.setText("字幕抽出がキャンセルされました")
     
     def on_extraction_finished(self):
@@ -674,7 +649,6 @@ class MainWindow(QMainWindow):
         self.extract_btn.setStyleSheet("")
 
         # 再抽出ボタンも無効化
-        self.re_extract_btn.setEnabled(False)
 
         logging.info("自動抽出ボタンが🛑抽出停止ボタンに変更されました")
         logging.info("=== 🛑 ボタン変更処理完了 ===")


### PR DESCRIPTION
## Summary
Issue #143の対応として、ツールバーの不要なUI要素を削除し、UIを整理しました。

## Changes
- ❌ **再抽出ボタンを削除**: 自動抽出と機能が重複しているため削除
- ❌ **QCチェックボタンを削除**: 利用タイミングが不明確で、メニューからアクセス可能
- ❌ **保存ボタンを削除**: メニューバーに既存の保存機能があるため削除  
- 🔄 **自動抽出 → 字幕抽出に変更**: より直感的な名称に変更

## Test plan
- [x] コード構文チェック
- [x] MainWindowクラスのインポート確認
- [x] 削除したボタンに関連する状態管理コードの除去確認

## 影響範囲
- ツールバーのボタン構成が変更され、よりシンプルになります
- 削除されたボタンの機能は他の方法（メニューバー等）でアクセス可能

Closes #143