### PR TITLE
fix: resolve major mypy type checking errors (407→278 errors)

### DIFF
--- a/app/core/cpu_profiler.py
+++ b/app/core/cpu_profiler.py
@@ -6,7 +6,7 @@ Basic CPU detection for OCR thread optimization, without complex profiling.
 import os
 import platform
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 
 @dataclass
@@ -48,11 +48,11 @@ def get_adaptive_thread_config() -> ThreadConfig:
 class CPUProfiler:
     """Simplified CPU profiler for basic detection."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.cpu_count = get_cpu_count()
         self.platform = platform.system()
 
-    def detect_cpu_profile(self):
+    def detect_cpu_profile(self) -> Dict[str, Any]:
         """Return basic CPU information."""
         cpu_name = platform.processor() or "Unknown"
         vendor = "Unknown"

--- a/app/core/csv/exporter.py
+++ b/app/core/csv/exporter.py
@@ -196,7 +196,7 @@ class SubtitleCSVExporter:
         seconds = total_seconds % 60
         return f"{minutes:02d}:{seconds:06.3f}"
 
-    def _write_csv_file(self, filepath: Path, rows: List[List[str]]):
+    def _write_csv_file(self, filepath: Path, rows: List[List[str]]) -> None:
         """CSVファイル書き込み"""
         # ディレクトリ作成
         filepath.parent.mkdir(parents=True, exist_ok=True)

--- a/app/core/csv/importer.py
+++ b/app/core/csv/importer.py
@@ -407,7 +407,7 @@ class CSVWorkflowValidator:
         source_file: Path, translated_files: List[Path]
     ) -> Dict[str, Any]:
         """翻訳ワークフロー全体の検証"""
-        result = {
+        result: Dict[str, Any] = {
             "valid": True,
             "errors": [],
             "warnings": [],

--- a/app/core/error_handler.py
+++ b/app/core/error_handler.py
@@ -216,15 +216,15 @@ class ErrorHandler(QObject):
 
         # アイコン決定
         icon_map = {
-            ErrorSeverity.INFO: QMessageBox.Information,
-            ErrorSeverity.WARNING: QMessageBox.Warning,
-            ErrorSeverity.ERROR: QMessageBox.Critical,
-            ErrorSeverity.CRITICAL: QMessageBox.Critical,
+            ErrorSeverity.INFO: QMessageBox.Icon.Information,
+            ErrorSeverity.WARNING: QMessageBox.Icon.Warning,
+            ErrorSeverity.ERROR: QMessageBox.Icon.Critical,
+            ErrorSeverity.CRITICAL: QMessageBox.Icon.Critical,
         }
 
         # メッセージボックス作成
         msg_box = QMessageBox(self.parent_widget)
-        msg_box.setIcon(icon_map.get(error_info.severity, QMessageBox.Critical))
+        msg_box.setIcon(icon_map.get(error_info.severity, QMessageBox.Icon.Critical))
         msg_box.setWindowTitle("エラーが発生しました")
         msg_box.setText(error_info.message)
 
@@ -246,15 +246,15 @@ class ErrorHandler(QObject):
 
         # ボタン設定
         if allow_retry:
-            msg_box.addButton("再試行", QMessageBox.AcceptRole)
-            msg_box.addButton("キャンセル", QMessageBox.RejectRole)
+            msg_box.addButton("再試行", QMessageBox.ButtonRole.AcceptRole)
+            msg_box.addButton("キャンセル", QMessageBox.ButtonRole.RejectRole)
         else:
-            msg_box.addButton("OK", QMessageBox.AcceptRole)
+            msg_box.addButton("OK", QMessageBox.ButtonRole.AcceptRole)
 
         # 復旧オプションがある場合
         recovery_buttons = {}
         for option_id, option_func in error_info.recovery_options.items():
-            button = msg_box.addButton(option_id, QMessageBox.ActionRole)
+            button = msg_box.addButton(option_id, QMessageBox.ButtonRole.ActionRole)
             recovery_buttons[button] = (option_id, option_func)
 
         # ダイアログ表示
@@ -273,7 +273,9 @@ class ErrorHandler(QObject):
                 return False
 
         # 再試行の場合
-        return allow_retry and msg_box.buttonRole(clicked_button) == QMessageBox.AcceptRole
+        return (
+            allow_retry and msg_box.buttonRole(clicked_button) == QMessageBox.ButtonRole.AcceptRole
+        )
 
     def create_progress_error_handler(
         self, operation_name: str, total_steps: int = 100

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -69,14 +69,17 @@ class Project:
     subtitles: List[SubtitleItem]
     version: str = "1.0"
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """初期化後の処理"""
         if isinstance(self.settings, dict):
             self.settings = ProjectSettings.from_dict(self.settings)
 
         # subtitlesが辞書のリストの場合、SubtitleItemに変換
         if self.subtitles and isinstance(self.subtitles[0], dict):
-            self.subtitles = [SubtitleItem.from_dict(item) for item in self.subtitles]
+            self.subtitles = [
+                SubtitleItem.from_dict(item) if isinstance(item, dict) else item
+                for item in self.subtitles
+            ]
 
     def add_subtitle(self, subtitle: SubtitleItem) -> None:
         """字幕を追加"""

--- a/app/core/project_manager.py
+++ b/app/core/project_manager.py
@@ -25,7 +25,7 @@ class ProjectMetadata:
     version: str = "1.0.0"
     description: str = ""
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """メタデータの初期化後処理"""
         if not self.id:
             self.id = str(uuid.uuid4())
@@ -81,7 +81,7 @@ class ProjectData:
 class ProjectManager:
     """プロジェクトファイル管理クラス"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.logger = logging.getLogger(__name__)
         self.current_project: Optional[ProjectData] = None
         self.current_file_path: Optional[Path] = None
@@ -197,7 +197,7 @@ class ProjectManager:
         """プロジェクトを別名で保存"""
         return self.save_project(project_data, file_path)
 
-    def update_subtitles(self, subtitles: List[SubtitleItem]):
+    def update_subtitles(self, subtitles: List[SubtitleItem]) -> None:
         """字幕データを更新"""
         if self.current_project is None:
             raise RuntimeError("プロジェクトが開かれていません")
@@ -213,7 +213,7 @@ class ProjectManager:
 
         self.logger.info(f"字幕データ更新: {len(subtitles)}件")
 
-    def update_translations(self, language: str, subtitles: List[SubtitleItem]):
+    def update_translations(self, language: str, subtitles: List[SubtitleItem]) -> None:
         """翻訳データを更新"""
         if self.current_project is None:
             raise RuntimeError("プロジェクトが開かれていません")
@@ -229,7 +229,7 @@ class ProjectManager:
 
         self.logger.info(f"翻訳データ更新 ({language}): {len(subtitles)}件")
 
-    def update_qc_results(self, qc_results: List[Dict[str, Any]]):
+    def update_qc_results(self, qc_results: List[Dict[str, Any]]) -> None:
         """QCチェック結果を更新"""
         if self.current_project is None:
             raise RuntimeError("プロジェクトが開かれていません")
@@ -257,7 +257,7 @@ class ProjectManager:
         # 現在は簡易的に modified_at を確認
         return True
 
-    def close_project(self):
+    def close_project(self) -> None:
         """プロジェクトを閉じる"""
         if self.current_project:
             self.logger.info(f"プロジェクト終了: {self.current_project.metadata.name}")
@@ -299,7 +299,7 @@ class ProjectManager:
             self.logger.error(f"プロジェクトデータ変換エラー: {e}")
             raise ValueError(f"プロジェクトファイルの形式が正しくありません: {e}")
 
-    def _create_backup(self, file_path: Path):
+    def _create_backup(self, file_path: Path) -> None:
         """バックアップファイルを作成"""
         if file_path.exists():
             backup_path = file_path.with_suffix(f".subproj.backup")

--- a/app/core/qc/rules.py
+++ b/app/core/qc/rules.py
@@ -228,7 +228,7 @@ class DuplicateTextRule(QCRule):
 
     def check(self, subtitles: List[SubtitleItem]) -> List[QCResult]:
         results = []
-        seen_texts = {}
+        seen_texts: Dict[str, int] = {}
 
         for i, subtitle in enumerate(subtitles):
             text = subtitle.text.strip().lower()
@@ -291,11 +291,11 @@ class ReadingSpeedRule(QCRule):
 class QCChecker:
     """QCチェッカー統合クラス"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.rules: List[QCRule] = []
         self._init_default_rules()
 
-    def _init_default_rules(self):
+    def _init_default_rules(self) -> None:
         """デフォルトルールの初期化"""
         self.rules = [
             LineLengthRule(max_chars=42),
@@ -308,15 +308,15 @@ class QCChecker:
             ReadingSpeedRule(max_chars_per_second=20.0),
         ]
 
-    def add_rule(self, rule: QCRule):
+    def add_rule(self, rule: QCRule) -> None:
         """ルールを追加"""
         self.rules.append(rule)
 
-    def remove_rule(self, rule_name: str):
+    def remove_rule(self, rule_name: str) -> None:
         """ルールを削除"""
         self.rules = [rule for rule in self.rules if rule.name != rule_name]
 
-    def enable_rule(self, rule_name: str, enabled: bool = True):
+    def enable_rule(self, rule_name: str, enabled: bool = True) -> None:
         """ルールの有効/無効を設定"""
         for rule in self.rules:
             if rule.name == rule_name:

--- a/app/core/settings_manager.py
+++ b/app/core/settings_manager.py
@@ -73,7 +73,7 @@ class AppSettings:
     ui: UISettings
     version: str = "1.0.0"
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """設定の初期化後処理"""
         # デフォルトの出力フォルダ設定
         if not self.output.output_folder:
@@ -104,7 +104,7 @@ class AppSettings:
 class SettingsManager:
     """設定管理クラス"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.logger = logging.getLogger(__name__)
         self._settings_path = self._get_settings_path()
         self._settings: Optional[AppSettings] = None
@@ -248,7 +248,7 @@ class SettingsManager:
             self.logger.error(f"設定変換エラー: {e}")
             return self._create_default_settings()
 
-    def _create_backup(self):
+    def _create_backup(self) -> None:
         """設定ファイルのバックアップを作成"""
         if self._settings_path.exists():
             backup_path = self._settings_path.with_suffix(".json.backup")
@@ -279,13 +279,14 @@ class SettingsManager:
             if recent_files_path.exists():
                 with open(recent_files_path, "r", encoding="utf-8") as f:
                     recent_files = json.load(f)
-                return recent_files.get("files", [])
+                files_list = recent_files.get("files", [])
+                return files_list if isinstance(files_list, list) else []
         except Exception as e:
             self.logger.error(f"最近使用したファイル読み込みエラー: {e}")
 
         return []
 
-    def save_recent_files(self, files: List[str]):
+    def save_recent_files(self, files: List[str]) -> None:
         """最近使用したファイルを保存"""
         recent_files_path = self.get_recent_files_path()
         try:
@@ -298,7 +299,7 @@ class SettingsManager:
         except Exception as e:
             self.logger.error(f"最近使用したファイル保存エラー: {e}")
 
-    def add_recent_file(self, file_path: str):
+    def add_recent_file(self, file_path: str) -> None:
         """最近使用したファイルに追加"""
         settings = self.load_settings()
         max_files = settings.ui.recent_files_count

--- a/app/core/translate/language_detector.py
+++ b/app/core/translate/language_detector.py
@@ -69,7 +69,7 @@ class LanguageDetector:
         "vi": "vi",
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         if not LANGDETECT_AVAILABLE:
             raise LanguageDetectionError("langdetectパッケージがインストールされていません")
 

--- a/app/main.py
+++ b/app/main.py
@@ -10,9 +10,10 @@ import sys
 import traceback
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 
-def is_console_available():
+def is_console_available() -> bool:
     """
     コンソールが利用可能かどうかを判定
     """
@@ -37,7 +38,7 @@ def is_console_available():
         return False
 
 
-def safe_input_prompt(message="Press Enter to continue..."):
+def safe_input_prompt(message: str = "Press Enter to continue...") -> None:
     """
     安全なinputプロンプト（コンソールが利用可能な場合のみ）
     """
@@ -48,7 +49,7 @@ def safe_input_prompt(message="Press Enter to continue..."):
             pass  # コンソールエラーは無視
 
 
-def setup_logging():
+def setup_logging() -> None:
     """
     デバッグ用ロギング設定
     """
@@ -82,10 +83,8 @@ def setup_logging():
         logger.info(f"_MEIPASS: {sys._MEIPASS}")
     logger.info(f"Log file: {log_file}")
 
-    return logger
 
-
-def setup_paths():
+def setup_paths() -> bool:
     """
     実行環境に応じてパスを設定
     PyInstallerでビルドされたバイナリとソースコード実行の両方に対応
@@ -112,7 +111,7 @@ def setup_paths():
         return False  # 開発環境実行
 
 
-def test_imports(logger):
+def test_imports(logger: Any) -> bool:
     """段階的インポートテスト"""
     logger.info("=== 段階的インポートテスト開始 ===")
 
@@ -174,9 +173,10 @@ def test_imports(logger):
         return False
 
 
-def main():
+def main() -> None:
     """メインエントリーポイント"""
-    logger = setup_logging()
+    setup_logging()
+    logger = logging.getLogger(__name__)
     logger.info("メインエントリーポイント開始")
 
     is_standalone = setup_paths()
@@ -248,7 +248,7 @@ def main():
         sys.exit(1)
 
 
-def show_standalone_error(error):
+def show_standalone_error(error: Exception) -> None:
     """スタンドアロンバイナリ実行時のエラー表示"""
     print("❌ エラー: バイナリファイルに問題があります")
     print()
@@ -264,7 +264,7 @@ def show_standalone_error(error):
     print(f"🐛 詳細エラー: {error}")
 
 
-def show_source_error(error):
+def show_source_error(error: Exception) -> None:
     """ソースコード実行時の依存関係エラー表示"""
     print("❌ エラー: 依存関係が不足しているか、実行方法に問題があります")
     print()
@@ -284,7 +284,7 @@ def show_source_error(error):
     print(f"🐛 元のエラー: {error}")
 
 
-def show_package_error(error):
+def show_package_error(error: Exception) -> None:
     """パッケージインストールエラー表示"""
     print("❌ エラー: 必要なパッケージがインストールされていません")
     print()

--- a/app/ui/dialogs/multilang_export_dialog.py
+++ b/app/ui/dialogs/multilang_export_dialog.py
@@ -226,10 +226,10 @@ class MultiLanguageExportDialog(QDialog):
                 self,
                 "確認",
                 f"出力先ディレクトリが存在しません。作成しますか？\n{output_dir}",
-                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             )
 
-            if reply == QMessageBox.Yes:
+            if reply == QMessageBox.StandardButton.Yes:
                 try:
                     output_dir.mkdir(parents=True, exist_ok=True)
                 except Exception as e:
@@ -248,9 +248,11 @@ class MultiLanguageExportDialog(QDialog):
             f"出力先: {output_dir}"
         )
 
-        reply = QMessageBox.question(self, "確認", message, QMessageBox.Yes | QMessageBox.No)
+        reply = QMessageBox.question(
+            self, "確認", message, QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+        )
 
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             # エクスポート実行のシグナルを送信
             self.export_requested.emit(selected_languages, str(output_dir))
             self.accept()

--- a/app/ui/dialogs/ocr_setup_dialog.py
+++ b/app/ui/dialogs/ocr_setup_dialog.py
@@ -80,7 +80,7 @@ class OCRSetupDialog(QDialog):
         title_font.setPointSize(14)
         title_font.setBold(True)
         title_label.setFont(title_font)
-        title_label.setAlignment(Qt.AlignCenter)
+        title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(title_label)
 
         # 説明文（組み込みモデル優先）
@@ -94,7 +94,7 @@ class OCRSetupDialog(QDialog):
             "• Tesseractエンジンの使用（軽量・高速）"
         )
         description.setWordWrap(True)
-        description.setAlignment(Qt.AlignLeft)
+        description.setAlignment(Qt.AlignmentFlag.AlignLeft)
         layout.addWidget(description)
 
         # 区切り線
@@ -116,7 +116,7 @@ class OCRSetupDialog(QDialog):
 
         # プログレスメッセージ
         self.progress_message = QLabel("")
-        self.progress_message.setAlignment(Qt.AlignCenter)
+        self.progress_message.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.progress_message.setVisible(False)
         layout.addWidget(self.progress_message)
 
@@ -205,10 +205,10 @@ class OCRSetupDialog(QDialog):
                 "- 所要時間: 1-5分程度\n"
                 "- 3回まで自動リトライします\n\n"
                 "続行しますか？",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.Yes,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.Yes,
             )
-            if reply != QMessageBox.Yes:
+            if reply != QMessageBox.StandardButton.Yes:
                 return
             self._setup_confirmed = True
 
@@ -242,11 +242,11 @@ class OCRSetupDialog(QDialog):
             "・Tesseractエンジンが使用されます\n"
             "・OCR精度がPaddleOCRより劣る場合があります\n"
             "・後で設定画面からPaddleOCRを有効化できます",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             self.reject()
 
     def on_progress_updated(self, message: str, progress: int):
@@ -285,11 +285,11 @@ class OCRSetupDialog(QDialog):
         detailed_message = self._format_error_message(error_message)
 
         error_dialog = QMessageBox(self)
-        error_dialog.setIcon(QMessageBox.Critical)
+        error_dialog.setIcon(QMessageBox.Icon.Critical)
         error_dialog.setWindowTitle("PaddleOCRセットアップエラー")
         error_dialog.setText("PaddleOCRのセットアップに失敗しました")
         error_dialog.setDetailedText(detailed_message)
-        error_dialog.setStandardButtons(QMessageBox.Ok)
+        error_dialog.setStandardButtons(QMessageBox.StandardButton.Ok)
         error_dialog.exec()
 
     def _format_error_message(self, error_message: str) -> str:
@@ -341,11 +341,11 @@ class OCRSetupDialog(QDialog):
                 self,
                 "確認",
                 "ダウンロード中です。中断しますか？",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
             )
 
-            if reply == QMessageBox.Yes:
+            if reply == QMessageBox.StandardButton.Yes:
                 self.worker.terminate()
                 self.worker.wait()
                 event.accept()

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -295,7 +295,7 @@ class MainWindow(QMainWindow):
     def create_toolbar(self):
         """ツールバーの作成"""
         toolbar = self.addToolBar("メイン")
-        toolbar.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        toolbar.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
 
         # 動画を開く
         open_btn = QPushButton("動画を開く")
@@ -349,7 +349,7 @@ class MainWindow(QMainWindow):
         main_layout = QHBoxLayout(central_widget)
 
         # スプリッター
-        splitter = QSplitter(Qt.Horizontal)
+        splitter = QSplitter(Qt.Orientation.Horizontal)
         main_layout.addWidget(splitter)
 
         # 左ペイン: 動画プレビュー
@@ -404,15 +404,15 @@ class MainWindow(QMainWindow):
     def setup_shortcuts(self):
         """ショートカットキーの設定"""
         # Space: 再生/一時停止
-        self.play_pause_shortcut = QShortcut(QKeySequence(Qt.Key_Space), self)
+        self.play_pause_shortcut = QShortcut(QKeySequence(Qt.Key.Key_Space), self)
         self.play_pause_shortcut.activated.connect(self.toggle_playback)
 
         # S: 字幕分割
-        self.split_shortcut = QShortcut(QKeySequence(Qt.Key_S), self)
+        self.split_shortcut = QShortcut(QKeySequence(Qt.Key.Key_S), self)
         self.split_shortcut.activated.connect(self.table_view.split_subtitle)
 
         # M: 字幕結合
-        self.merge_shortcut = QShortcut(QKeySequence(Qt.Key_M), self)
+        self.merge_shortcut = QShortcut(QKeySequence(Qt.Key.Key_M), self)
         self.merge_shortcut.activated.connect(self.table_view.merge_subtitle)
 
         # Ctrl+Q: QCチェック
@@ -420,10 +420,10 @@ class MainWindow(QMainWindow):
         self.qc_shortcut.activated.connect(self.run_qc_check)
 
         # 左右矢印: フレーム移動
-        self.frame_back_shortcut = QShortcut(QKeySequence(Qt.Key_Left), self)
+        self.frame_back_shortcut = QShortcut(QKeySequence(Qt.Key.Key_Left), self)
         self.frame_back_shortcut.activated.connect(self.seek_frame_back)
 
-        self.frame_forward_shortcut = QShortcut(QKeySequence(Qt.Key_Right), self)
+        self.frame_forward_shortcut = QShortcut(QKeySequence(Qt.Key.Key_Right), self)
         self.frame_forward_shortcut.activated.connect(self.seek_frame_forward)
 
     def toggle_playback(self):
@@ -497,10 +497,10 @@ class MainWindow(QMainWindow):
                     f"ファイル形式 '{file_ext}' は推奨されていません。\n"
                     f"推奨形式: {', '.join(supported_formats)}\n\n"
                     f"続行しますか？",
-                    QMessageBox.Yes | QMessageBox.No,
-                    QMessageBox.No,
+                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                    QMessageBox.StandardButton.No,
                 )
-                if reply == QMessageBox.No:
+                if reply == QMessageBox.StandardButton.No:
                     return
 
             self.current_video_path = file_path
@@ -533,7 +533,7 @@ class MainWindow(QMainWindow):
 
         error_dialog = QMessageBox(self)
         error_dialog.setWindowTitle("動画コーデックエラー")
-        error_dialog.setIcon(QMessageBox.Critical)
+        error_dialog.setIcon(QMessageBox.Icon.Critical)
 
         error_text = f"動画ファイルを開けませんでした。\n\n"
         error_text += f"ファイル: {Path(file_path).name}\n"
@@ -725,11 +725,11 @@ class MainWindow(QMainWindow):
             self,
             "キャンセル確認",
             "字幕抽出を中止しますか？\n\n" "進行中の処理が停止され、現在までの結果は破棄されます。",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             # キャンセル実行
             logging.info("ユーザーがキャンセルを確定しました")
             # 自動抽出ボタン（現在はキャンセルボタン）を「キャンセル中...」に変更
@@ -791,11 +791,11 @@ class MainWindow(QMainWindow):
             self,
             "字幕抽出の開始確認",
             message,
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.Yes,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.Yes,
         )
 
-        return reply == QMessageBox.Yes
+        return reply == QMessageBox.StandardButton.Yes
 
     def _show_cancel_button_with_force(self):
         """キャンセルボタンを確実に表示する強化メソッド"""
@@ -1018,11 +1018,11 @@ class MainWindow(QMainWindow):
         msg_box.setText(message)
 
         if summary["error"] > 0:
-            msg_box.setIcon(QMessageBox.Critical)
+            msg_box.setIcon(QMessageBox.Icon.Critical)
         elif summary["warning"] > 0:
-            msg_box.setIcon(QMessageBox.Warning)
+            msg_box.setIcon(QMessageBox.Icon.Warning)
         else:
-            msg_box.setIcon(QMessageBox.Information)
+            msg_box.setIcon(QMessageBox.Icon.Information)
 
         msg_box.exec()
 
@@ -1644,11 +1644,11 @@ class MainWindow(QMainWindow):
                     self,
                     "プロジェクト読み込み警告",
                     error_msg,
-                    QMessageBox.Yes | QMessageBox.No,
-                    QMessageBox.No,
+                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                    QMessageBox.StandardButton.No,
                 )
 
-                if reply == QMessageBox.No:
+                if reply == QMessageBox.StandardButton.No:
                     # ユーザーがキャンセルした場合、ProjectManagerの状態をロールバック
                     project_manager.current_project = previous_project
                     project_manager.current_file_path = previous_file_path
@@ -1667,11 +1667,11 @@ class MainWindow(QMainWindow):
                         self,
                         "動画ファイルが見つかりません",
                         f"動画ファイルが見つかりません:\n{video_path}\n\n新しい場所を指定しますか？",
-                        QMessageBox.Yes | QMessageBox.No,
-                        QMessageBox.Yes,
+                        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                        QMessageBox.StandardButton.Yes,
                     )
 
-                    if reply == QMessageBox.Yes:
+                    if reply == QMessageBox.StandardButton.Yes:
                         new_video_path, _ = QFileDialog.getOpenFileName(
                             self,
                             "動画ファイルを選択",

--- a/app/ui/views/player_view.py
+++ b/app/ui/views/player_view.py
@@ -59,7 +59,7 @@ class PlayerView(QWidget):
         self.video_label = QLabel()
         self.video_label.setMinimumSize(400, 300)
         self.video_label.setStyleSheet("border: 1px solid gray; background-color: black;")
-        self.video_label.setAlignment(Qt.AlignCenter)
+        self.video_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.video_label.setText(
             "動画をドラッグ&ドロップするか、\\n「動画を開く」ボタンから読み込んでください"
         )
@@ -87,7 +87,7 @@ class PlayerView(QWidget):
         layout.addLayout(control_layout)
 
         # シークバー
-        self.seek_slider = QSlider(Qt.Horizontal)
+        self.seek_slider = QSlider(Qt.Orientation.Horizontal)
         self.seek_slider.setEnabled(False)
         self.seek_slider.valueChanged.connect(self.seek_to_frame)
         layout.addWidget(self.seek_slider)

--- a/app/ui/views/table_view.py
+++ b/app/ui/views/table_view.py
@@ -36,7 +36,7 @@ class MultilineTextDelegate(QStyledItemDelegate):
         """エディターを作成"""
         if index.column() == 3:  # 本文列の場合
             editor = QPlainTextEdit(parent)
-            editor.setWordWrapMode(QTextOption.WrapAtWordBoundaryOrAnywhere)
+            editor.setWordWrapMode(QTextOption.WrapMode.WrapAtWordBoundaryOrAnywhere)
             # イベントフィルターを設定
             editor.installEventFilter(self)
             return editor
@@ -45,7 +45,7 @@ class MultilineTextDelegate(QStyledItemDelegate):
     def setEditorData(self, editor, index):
         """エディターにデータを設定"""
         if isinstance(editor, QPlainTextEdit):
-            text = index.model().data(index, Qt.EditRole)
+            text = index.model().data(index, Qt.ItemDataRole.EditRole)
             editor.setPlainText(text or "")
         else:
             super().setEditorData(editor, index)
@@ -54,7 +54,7 @@ class MultilineTextDelegate(QStyledItemDelegate):
         """エディターからモデルにデータを設定"""
         if isinstance(editor, QPlainTextEdit):
             text = editor.toPlainText()
-            model.setData(index, text, Qt.EditRole)
+            model.setData(index, text, Qt.ItemDataRole.EditRole)
         else:
             super().setModelData(editor, model, index)
 
@@ -64,8 +64,8 @@ class MultilineTextDelegate(QStyledItemDelegate):
             key_event = event
 
             # Ctrl+Enter (Windows/Linux) または Cmd+Enter (Mac) で次の字幕に移動
-            if key_event.key() == Qt.Key_Return and key_event.modifiers() & (
-                Qt.ControlModifier | Qt.MetaModifier
+            if key_event.key() == Qt.Key.Key_Return and key_event.modifiers() & (
+                Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.MetaModifier
             ):
 
                 # エディターを閉じて次の字幕に移動
@@ -75,7 +75,7 @@ class MultilineTextDelegate(QStyledItemDelegate):
                 return True
 
             # 通常のEnterキーは改行として処理（デフォルト動作）
-            elif key_event.key() == Qt.Key_Return and not key_event.modifiers():
+            elif key_event.key() == Qt.Key.Key_Return and not key_event.modifiers():
                 return False  # デフォルトの改行動作を許可
 
         return super().eventFilter(editor, event)
@@ -165,10 +165,10 @@ class SubtitleTableView(QWidget):
 
         # テーブルの設定
         header = self.table.horizontalHeader()
-        header.setSectionResizeMode(0, QHeaderView.Fixed)  # インデックス列
-        header.setSectionResizeMode(1, QHeaderView.Fixed)  # 開始時間列
-        header.setSectionResizeMode(2, QHeaderView.Fixed)  # 終了時間列
-        header.setSectionResizeMode(3, QHeaderView.Stretch)  # 本文列
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Fixed)  # インデックス列
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Fixed)  # 開始時間列
+        header.setSectionResizeMode(2, QHeaderView.ResizeMode.Fixed)  # 終了時間列
+        header.setSectionResizeMode(3, QHeaderView.ResizeMode.Stretch)  # 本文列
 
         self.table.setColumnWidth(0, 50)  # インデックス
         self.table.setColumnWidth(1, 100)  # 開始時間
@@ -176,20 +176,20 @@ class SubtitleTableView(QWidget):
 
         # 垂直ヘッダーの設定（行の高さを可変にする）
         vertical_header = self.table.verticalHeader()
-        vertical_header.setSectionResizeMode(QHeaderView.ResizeToContents)
+        vertical_header.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
 
         # 改行表示のための設定
         self.table.setWordWrap(True)
 
         # 選択モード設定
-        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.table.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
 
         # イベント接続
         self.table.cellChanged.connect(self.on_cell_changed)
         self.table.itemSelectionChanged.connect(self.on_selection_changed)
         self.table.customContextMenuRequested.connect(self.show_context_menu)
-        self.table.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.table.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.table.cellDoubleClicked.connect(self.on_cell_double_clicked)
 
         layout.addWidget(self.table)
@@ -224,8 +224,8 @@ class SubtitleTableView(QWidget):
         for row, subtitle in enumerate(self.subtitles):
             # インデックス
             index_item = QTableWidgetItem(str(subtitle.index))
-            index_item.setFlags(index_item.flags() & ~Qt.ItemIsEditable)
-            index_item.setTextAlignment(Qt.AlignCenter)
+            index_item.setFlags(index_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+            index_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             self.table.setItem(row, 0, index_item)
 
             # 開始時間
@@ -244,7 +244,7 @@ class SubtitleTableView(QWidget):
             # 改行が含まれている場合の特別処理
             if "\n" in subtitle.text:
                 # 改行を表示するためにWordWrapを有効化
-                text_item.setData(Qt.DisplayRole, subtitle.text)
+                text_item.setData(Qt.ItemDataRole.DisplayRole, subtitle.text)
 
                 # 行数に応じて行の高さを調整
                 line_count = subtitle.text.count("\n") + 1
@@ -361,7 +361,7 @@ class SubtitleTableView(QWidget):
                 item = self.table.item(self.current_highlight_row, col)
                 if item:
                     # システムのデフォルト背景色に戻す
-                    default_bg = QApplication.palette().color(QPalette.Base)
+                    default_bg = QApplication.palette().color(QPalette.ColorRole.Base)
                     item.setBackground(default_bg)
 
         # 現在時間に該当する字幕を検索
@@ -464,11 +464,11 @@ class SubtitleTableView(QWidget):
             self,
             "確認",
             "選択された字幕を削除しますか？",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             del self.subtitles[row]
             self.refresh_table()
             self.subtitles_reordered.emit()

--- a/app/ui/views/translate_view.py
+++ b/app/ui/views/translate_view.py
@@ -485,11 +485,11 @@ class TranslateView(QDialog):
         msg_box.setWindowTitle(title)
         msg_box.setText(guidance)
         msg_box.setDetailedText(f"詳細エラー情報:\\n{error_message}")
-        msg_box.setStandardButtons(QMessageBox.Ok | QMessageBox.Help)
+        msg_box.setStandardButtons(QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Help)
 
         # ヘルプボタンで設定画面を開く
         result = msg_box.exec()
-        if result == QMessageBox.Help:
+        if result == QMessageBox.StandardButton.Help:
             self.open_settings_dialog()
 
     def export_csv(self):


### PR DESCRIPTION
## 修正内容

### 🎯 PySide6 enum アクセス問題の完全解決
- `Qt.EditRole` → `Qt.ItemDataRole.EditRole`
- `QMessageBox.Yes` → `QMessageBox.StandardButton.Yes`  
- `QMessageBox.Information` → `QMessageBox.Icon.Information`
- `QHeaderView.Fixed` → `QHeaderView.ResizeMode.Fixed`
- その他多数のenum属性を正しい形式に修正

### 📝 関数型アノテーションの追加
- `__init__()` → `__init__(self) -> None:`
- `__post_init__()` → `__post_init__(self) -> None:`
- 戻り値型が不足している主要な関数に型アノテーション追加

### 📦 import文の修正
- `typing.Any` の不足を解決
- 必要な型importを追加

### 🏷️ 変数型アノテーションの改善
- 辞書・リストの型を明示的に指定
- `seen_texts: Dict[str, int] = {}` など

## 📊 成果
- **mypy エラー数**: 407個 → 278個（129個減少）
- PySide6関連の型エラーを完全解決
- 主要な型安全性の問題を修正

## Test plan
- [x] `make type-check` でエラー数大幅減少確認
- [x] `make format-check` 成功
- [x] PySide6 enum問題解決確認

Closes #185