### PR TITLE
fix: enhance PyInstaller spec to bundle PaddleOCR resources properly

### DIFF
--- a/vlog-subs-tool.spec
+++ b/vlog-subs-tool.spec
@@ -27,12 +27,20 @@ hidden_imports = [
     'PySide6.QtMultimedia',
     'PySide6.QtMultimediaWidgets',
 
-    # PaddleOCR関連（コア機能のみ、PaddleX除外）
+    # PaddleOCR関連（Issue #219対応：動的インポートされるモジュールも含む）
     'paddleocr',
     'paddlepaddle',
     'paddle',
     'paddle.utils',
     'paddle.utils.cpp_extension',
+    'paddle.fluid',
+    'paddle.inference',
+    'paddleocr.tools.infer.utility',
+    'paddleocr.tools.infer.predict_system',
+    'paddleocr.paddleocr',
+    'paddleocr.tools.infer.predict_det',
+    'paddleocr.tools.infer.predict_rec',
+    'paddleocr.tools.infer.predict_cls',
 
     # OpenCV関連（必須）
     'cv2',
@@ -81,12 +89,31 @@ if app_models_path.exists():
     datas.append(('app/models', 'models'))
     print(f"Added app models directory: {app_models_path}")
 
-# PaddleOCR関連のデータファイル（必要最小限）
+# PaddleOCR関連のデータファイル（Issue #219対応：必要なリソースを確実にバンドル）
 try:
     import paddleocr
-    print("PaddleOCR found - lightweight support enabled")
+    from PyInstaller.utils.hooks import collect_data_files
+
+    # PaddleOCRのYAML/dictionary/configファイルを確実に収集
+    paddleocr_data_files = collect_data_files(
+        'paddleocr',
+        includes=['**/*.yml', '**/*.yaml', '**/*.json', '**/*.txt', '**/*.dict']
+    )
+    datas.extend(paddleocr_data_files)
+    print(f"PaddleOCR found - collected {len(paddleocr_data_files)} data files")
+
+    # Paddleのコアリソースも収集
+    paddle_data_files = collect_data_files(
+        'paddle',
+        includes=['**/*.yml', '**/*.yaml', '**/*.json']
+    )
+    datas.extend(paddle_data_files)
+    print(f"Paddle core - collected {len(paddle_data_files)} data files")
+
 except ImportError as e:
     print(f"Warning: PaddleOCR not available: {e}")
+except Exception as e:
+    print(f"Warning: PaddleOCR data collection failed: {e}")
 
 # バイナリの定義（PaddleOCRモデルなど）
 binaries = []
@@ -164,11 +191,8 @@ excludes = [
     'flake8',
 ]
 
-# フックパス設定（存在する場合のみ）
+# フックパス設定（Issue #219: 簡素化されたアプローチのため無効化）
 hookspath_list = []
-hooks_dir = project_root / "hooks"
-if hooks_dir.exists():
-    hookspath_list.append(str(hooks_dir))
 
 # 分析設定（完全スタンドアロン対応）
 a = Analysis(
@@ -182,7 +206,7 @@ a = Analysis(
     hiddenimports=hidden_imports,
     hookspath=hookspath_list,
     hooksconfig={},
-    runtime_hooks=['hooks/rthook-paddlex.py'],  # Issue #207: PaddleXスタブ化でPaddleOCRインポートエラーを回避
+    runtime_hooks=[],  # Issue #219: 簡素化されたアプローチ（PaddleXスタブ不要）
     excludes=excludes,
     win_no_prefer_redirects=False,
     win_private_assemblies=False,


### PR DESCRIPTION
## Summary
PR #218のコメントで指摘されたPyInstaller specの問題を修正し、PaddleOCRのリソースファイルとhidden importsを適切にバンドルするようにしました。

## What Changed
- **PaddleOCRデータファイル収集を強化**: `collect_data_files`を使用してYAML/dictionary/configファイルを確実にバンドル
- **hidden imports追加**: 動的にインポートされるPaddleOCRモジュールを明示的に指定
- **runtime hooks簡素化**: PaddleXスタブ化のためのruntime hookを削除し、シンプルなアプローチに変更

## Why
PR #218で導入された最小構成のspecでは、PaddleOCRの動作に必要な以下のリソースが不足していました：
- PaddleOCRのYAML/dictionary files (`paddleocr/ppocr/**`)
- 動的にインポートされるオプションモジュール
- 必要なhidden imports

この結果、バイナリ実行時に`PaddleOCR()`の初期化で`ImportError`/`FileNotFoundError`が発生していました。

## How
1. `collect_data_files`を使用してPaddleOCRとPaddleの設定ファイルを明示的に収集
2. PaddleOCRが動的にインポートする推論モジュールをhidden importsに追加
3. Runtime hooksを削除してシンプルな構成に変更

## Testing
- `make quality`でformat/type/test checkが通ることを確認
- PaddleOCRのリソースファイルが適切にバンドルされることを確認

## Impact
- **バイナリ実行時**: PaddleOCR()が正常に初期化できるようになる
- **互換性**: 既存のOCR機能に影響なし
- **保守性**: Runtime hookの依存関係が削除され、よりシンプルなビルド構成

Closes #219