### PR TITLE
Fix PyInstaller PaddleX packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # vlog-subs-tool Makefile
 # ローカル開発とCode Quality Checks用（venv環境対応）
 
-.PHONY: help venv install install-dev clean clean-all format format-check lint type-check test quality quality-fix build setup all security outdated ci
+.PHONY: help venv install install-dev clean clean-all format format-check lint type-check test quality quality-fix build build-verbose build-debug setup all security outdated ci
 
 # venv環境設定
 VENV_DIR := venv
@@ -46,11 +46,13 @@ help:
 	@echo "  quality-fix  - 自動修正可能な問題を修正"
 	@echo ""
 	@echo "🏗️ ビルド:"
-	@echo "  build        - PyInstallerでビルド"
-	@echo "  build-mac    - macOS用バイナリビルド"
-	@echo "  build-linux  - Linux用バイナリビルド"
+	@echo "  build         - PyInstallerでビルド"
+	@echo "  build-verbose - 詳細ログ付きPyInstallerビルド"
+	@echo "  build-debug   - デバッグ情報付きビルド"
+	@echo "  build-mac     - macOS用バイナリビルド"
+	@echo "  build-linux   - Linux用バイナリビルド"
 	@echo "  build-windows - Windows用バイナリビルド"
-	@echo "  test-binary  - ビルドしたバイナリの動作テスト"
+	@echo "  test-binary   - ビルドしたバイナリの動作テスト"
 	@echo ""
 	@echo "🔄 統合:"
 	@echo "  all          - setup + quality + build"
@@ -173,10 +175,61 @@ build:
 		exit 1; \
 	fi
 	@echo "PyInstallerでビルド中..."
-	$(PYTHON) -m PyInstaller --clean --noconfirm vlog-subs-tool.spec --distpath dist/local-build --workpath build/local-build
+	@mkdir -p logs
+	@echo "ビルドログを保存中: logs/build.log"
+	$(PYTHON) -m PyInstaller --clean --noconfirm vlog-subs-tool.spec --distpath dist/local-build --workpath build/local-build 2>&1 | tee logs/build.log
 	@echo "ビルド完了: dist/local-build/vlog-subs-tool/"
+	@echo "ビルドログ: logs/build.log"
 	@echo "ビルドサイズ:"
 	du -sh dist/local-build/vlog-subs-tool 2>/dev/null || echo "ビルド出力が見つかりません"
+
+# 詳細ログ付きビルド
+build-verbose:
+	@echo "=== PyInstaller Build (Verbose) ==="
+	@if [ ! -f "$(VENV_PYTHON)" ]; then \
+		echo "❌ venv環境が見つかりません。'make setup' を実行してください"; \
+		exit 1; \
+	fi
+	@echo "詳細ログ付きでPyInstallerビルド中..."
+	@mkdir -p logs
+	@echo "詳細ビルドログを保存中: logs/build-verbose.log"
+	$(PYTHON) -m PyInstaller --clean --noconfirm --log-level=DEBUG vlog-subs-tool.spec --distpath dist/local-build --workpath build/local-build 2>&1 | tee logs/build-verbose.log
+	@echo "詳細ビルド完了: dist/local-build/vlog-subs-tool/"
+	@echo "詳細ログ: logs/build-verbose.log"
+	@echo "ビルドサイズ:"
+	du -sh dist/local-build/vlog-subs-tool 2>/dev/null || echo "ビルド出力が見つかりません"
+
+# デバッグ情報付きビルド
+build-debug:
+	@echo "=== PyInstaller Build (Debug Mode) ==="
+	@if [ ! -f "$(VENV_PYTHON)" ]; then \
+		echo "❌ venv環境が見つかりません。'make setup' を実行してください"; \
+		exit 1; \
+	fi
+	@echo "デバッグモードでPyInstallerビルド中..."
+	@mkdir -p logs
+	@echo "デバッグビルドログを保存中: logs/build-debug.log"
+	@echo "環境変数情報を保存..."
+	@echo "=== Build Environment ===" > logs/build-debug.log
+	@echo "Date: $$(date)" >> logs/build-debug.log
+	@echo "Platform: $$(uname -a)" >> logs/build-debug.log
+	@echo "Python Version: $$($(PYTHON) --version)" >> logs/build-debug.log
+	@echo "PyInstaller Version: $$($(PYTHON) -m PyInstaller --version)" >> logs/build-debug.log
+	@echo "Working Directory: $$(pwd)" >> logs/build-debug.log
+	@echo "Environment Variables:" >> logs/build-debug.log
+	@env | grep -E "(PYTHONPATH|PATH|.*PADDLE.*|.*CUDA.*)" >> logs/build-debug.log || echo "No relevant env vars found" >> logs/build-debug.log
+	@echo "" >> logs/build-debug.log
+	@echo "=== PyInstaller Output ===" >> logs/build-debug.log
+	$(PYTHON) -m PyInstaller --clean --noconfirm --log-level=DEBUG --debug=all vlog-subs-tool.spec --distpath dist/local-build --workpath build/local-build 2>&1 | tee -a logs/build-debug.log
+	@echo "デバッグビルド完了: dist/local-build/vlog-subs-tool/"
+	@echo "デバッグログ: logs/build-debug.log"
+	@echo "ビルドサイズ:"
+	du -sh dist/local-build/vlog-subs-tool 2>/dev/null || echo "ビルド出力が見つかりません"
+	@echo ""
+	@echo "🔍 トラブルシューティング情報:"
+	@echo "  - ログファイル: logs/build-debug.log"
+	@echo "  - ワークディレクトリ: build/local-build/"
+	@echo "  - 出力ディレクトリ: dist/local-build/"
 
 # プラットフォーム別バイナリビルド（Issue #200 対応）
 build-mac:

--- a/README.md
+++ b/README.md
@@ -214,9 +214,10 @@ pyinstaller --clean \
 ```
 
 > `vlog-subs-tool.spec` は `hooks/` ディレクトリを自動登録し、
-> `paddlex/.version` や各種設定ファイルをバイナリに同梱します。
-> （PaddleOCR が内部で paddlex を import する際の FileNotFoundError を
-> 防ぐためのフックです）
+> `paddlex/.version` や各種設定ファイルに加えて
+> `paddleocr` / `paddlepaddle` / `paddlex` のメタデータもバイナリに同梱します。
+> （PaddleOCR が内部で paddlex を import する際の FileNotFoundError と
+> `importlib.metadata.version("paddleocr")` が失敗する問題を防ぐフックです）
 
 Windows PowerShell の例:
 
@@ -240,7 +241,10 @@ pyinstaller app/ui/main_window.py \
   --name vlog-subs-tool \
   --additional-hooks-dir hooks \
   --collect-submodules paddlex \
-  --collect-data paddlex
+  --collect-data paddlex \
+  --collect-metadata paddleocr \
+  --collect-metadata paddlepaddle \
+  --collect-metadata paddlex
 ```
 
 > `hooks/hook-paddlex.py` が `.version` や YAML/JSON 設定ファイルを収集し、

--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ pyinstaller --clean \
   vlog-subs-tool.spec
 ```
 
+> `vlog-subs-tool.spec` は `hooks/` ディレクトリを自動登録し、
+> `paddlex/.version` や各種設定ファイルをバイナリに同梱します。
+> （PaddleOCR が内部で paddlex を import する際の FileNotFoundError を
+> 防ぐためのフックです）
+
 Windows PowerShell の例:
 
 ```powershell
@@ -222,6 +227,24 @@ pyinstaller `
   --workpath .\build\windows `
   .\vlog-subs-tool.spec
 ```
+
+### 2.1 `--onefile` / カスタムエントリーポイントでビルドする場合
+
+`vlog-subs-tool.spec` を使わずに `pyinstaller app/ui/main_window.py --onefile`
+のように直接ビルドする場合は、paddlex のデータファイルを明示的に収集する
+フックを有効にしてください。
+
+```bash
+pyinstaller app/ui/main_window.py \
+  --onefile \
+  --name vlog-subs-tool \
+  --additional-hooks-dir hooks \
+  --collect-submodules paddlex \
+  --collect-data paddlex
+```
+
+> `hooks/hook-paddlex.py` が `.version` や YAML/JSON 設定ファイルを収集し、
+> onefile 展開後でも PaddleOCR の import が失敗しなくなります。
 
 > `scripts/build_binary.sh`（Linux/macOS用）や `scripts/test_exe.ps1`
 > （Windows用）を使うと同じコマンドを自動実行できます。どちらも spec を

--- a/hooks/hook-paddlex.py
+++ b/hooks/hook-paddlex.py
@@ -10,7 +10,7 @@ files the package loads dynamically and registers all of its lazy imports so
 
 from __future__ import annotations
 
-from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules, copy_metadata
 
 _datas = []
 _hiddenimports = []
@@ -37,6 +37,14 @@ try:
     # paddlex exposes optional helper modules that paddleocr imports lazily.
     # Register all of them so PyInstaller pulls the bytecode into the build.
     _hiddenimports.extend(collect_submodules("paddlex"))
+
+    # Ensure the package's distribution metadata is preserved so
+    # importlib.metadata lookups continue to work inside the frozen app.
+    try:
+        _datas.extend(copy_metadata("paddlex"))
+    except Exception:
+        # copy_metadata raises PackageNotFoundError when the distribution is absent.
+        pass
 except ModuleNotFoundError:
     # The project does not always install paddlex (it is an optional
     # dependency).  Allow the build to continue without it; if the package is

--- a/hooks/hook-paddlex.py
+++ b/hooks/hook-paddlex.py
@@ -1,0 +1,49 @@
+"""PyInstaller hook to ensure paddlex data files ship with the binary.
+
+paddlex lazily reads its `.version` marker along with various configuration
+files when imported.  PyInstaller does not automatically collect dotfiles, so
+building without an explicit hook leads to runtime FileNotFoundError on
+`paddlex/.version` once the app is frozen.  This hook mirrors the subset of
+files the package loads dynamically and registers all of its lazy imports so
+`paddleocr` can depend on them safely.
+"""
+
+from __future__ import annotations
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+_datas = []
+_hiddenimports = []
+
+try:
+    # Collect the `.version` marker alongside the lightweight configs paddlex
+    # touches when bootstrapping.  The explicit patterns keep the hook fast
+    # while still covering nested resources.
+    _datas.extend(
+        collect_data_files(
+            "paddlex",
+            includes=[
+                ".version",
+                "*.version",
+                "**/.version",
+                "**/*.json",
+                "**/*.yml",
+                "**/*.yaml",
+                "**/*.txt",
+            ],
+        )
+    )
+
+    # paddlex exposes optional helper modules that paddleocr imports lazily.
+    # Register all of them so PyInstaller pulls the bytecode into the build.
+    _hiddenimports.extend(collect_submodules("paddlex"))
+except ModuleNotFoundError:
+    # The project does not always install paddlex (it is an optional
+    # dependency).  Allow the build to continue without it; if the package is
+    # missing at runtime paddleocr will gracefully fall back to the pure
+    # PaddlePaddle path.
+    pass
+
+# PyInstaller expects module-level names `datas` and `hiddenimports`.
+datas = _datas
+hiddenimports = _hiddenimports

--- a/vlog-subs-tool.spec
+++ b/vlog-subs-tool.spec
@@ -4,7 +4,9 @@
 The goal is to mirror the behaviour of running the source tree directly.
 This spec includes necessary PaddleOCR resources and hidden imports while
 avoiding custom hooks, module exclusions, UPX compression or other complex
-optimisations. Everything the runtime might touch is included in an onedir build.
+optimisations. Everything the runtime might touch is included in an onedir
+build.  A local hook directory is registered so we can bundle paddlex' data
+files (notably the `.version` marker) that PaddleOCR accesses lazily.
 """
 
 from pathlib import Path
@@ -39,6 +41,25 @@ try:
     _datas.extend(paddle_datas)
     print(f"Collected {len(paddle_datas)} Paddle data files")
 
+    try:
+        paddlex_datas = collect_data_files(
+            "paddlex",
+            includes=[
+                ".version",
+                "*.version",
+                "**/.version",
+                "**/*.yml",
+                "**/*.yaml",
+                "**/*.json",
+                "**/*.txt",
+            ],
+        )
+        _datas.extend(paddlex_datas)
+        if paddlex_datas:
+            print(f"Collected {len(paddlex_datas)} PaddleX data files")
+    except ModuleNotFoundError:
+        print("PaddleX is not installed; skipping PaddleX data collection")
+
 except ImportError:
     print("Warning: PyInstaller hooks not available, skipping data collection")
 except Exception as e:
@@ -66,6 +87,7 @@ _hiddenimports = [
     "paddleocr.tools.infer.predict_rec",
     "paddleocr.tools.infer.predict_cls",
     "paddleocr.paddleocr",
+    "paddlex",
     # Core image processing libraries
     "cv2",
     "numpy",
@@ -92,7 +114,7 @@ a = Analysis(
     binaries=[],
     datas=_datas,
     hiddenimports=_hiddenimports,
-    hookspath=[],
+    hookspath=[str(project_root / "hooks")],
     hooksconfig={},
     runtime_hooks=[],
     excludes=[],

--- a/vlog-subs-tool.spec
+++ b/vlog-subs-tool.spec
@@ -25,45 +25,65 @@ _datas = [
     (str(project_root / "app" / "models"), "app/models"),
 ]
 
-# Collect PaddleOCR data files (YAML/dictionary/config files) for OCR functionality
+# Collect PaddleOCR data files (YAML/dictionary/config files) and package metadata
 try:
-    from PyInstaller.utils.hooks import collect_data_files
-
-    # Collect PaddleOCR's configuration and dictionary files
-    paddleocr_datas = collect_data_files(
-        "paddleocr", includes=["**/*.yml", "**/*.yaml", "**/*.json", "**/*.txt", "**/*.dict"]
-    )
-    _datas.extend(paddleocr_datas)
-    print(f"Collected {len(paddleocr_datas)} PaddleOCR data files")
-
-    # Collect Paddle core configuration files
-    paddle_datas = collect_data_files("paddle", includes=["**/*.yml", "**/*.yaml", "**/*.json"])
-    _datas.extend(paddle_datas)
-    print(f"Collected {len(paddle_datas)} Paddle data files")
-
-    try:
-        paddlex_datas = collect_data_files(
-            "paddlex",
-            includes=[
-                ".version",
-                "*.version",
-                "**/.version",
-                "**/*.yml",
-                "**/*.yaml",
-                "**/*.json",
-                "**/*.txt",
-            ],
-        )
-        _datas.extend(paddlex_datas)
-        if paddlex_datas:
-            print(f"Collected {len(paddlex_datas)} PaddleX data files")
-    except ModuleNotFoundError:
-        print("PaddleX is not installed; skipping PaddleX data collection")
-
+    from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 except ImportError:
     print("Warning: PyInstaller hooks not available, skipping data collection")
-except Exception as e:
-    print(f"Warning: Data collection failed: {e}")
+else:
+    try:
+        # Collect PaddleOCR's configuration and dictionary files
+        paddleocr_datas = collect_data_files(
+            "paddleocr",
+            includes=["**/*.yml", "**/*.yaml", "**/*.json", "**/*.txt", "**/*.dict"],
+        )
+        _datas.extend(paddleocr_datas)
+        print(f"Collected {len(paddleocr_datas)} PaddleOCR data files")
+
+        # Collect Paddle core configuration files
+        paddle_datas = collect_data_files(
+            "paddle", includes=["**/*.yml", "**/*.yaml", "**/*.json"]
+        )
+        _datas.extend(paddle_datas)
+        print(f"Collected {len(paddle_datas)} Paddle data files")
+
+        try:
+            paddlex_datas = collect_data_files(
+                "paddlex",
+                includes=[
+                    ".version",
+                    "*.version",
+                    "**/.version",
+                    "**/*.yml",
+                    "**/*.yaml",
+                    "**/*.json",
+                    "**/*.txt",
+                ],
+            )
+            _datas.extend(paddlex_datas)
+            if paddlex_datas:
+                print(f"Collected {len(paddlex_datas)} PaddleX data files")
+        except ModuleNotFoundError:
+            print("PaddleX is not installed; skipping PaddleX data collection")
+
+        def _extend_with_metadata(dist_name: str, label: str) -> None:
+            try:
+                metadata_entries = copy_metadata(dist_name)
+            except ModuleNotFoundError:
+                print(f"{label} is not installed; skipping metadata collection")
+            except Exception as metadata_error:  # pragma: no cover - diagnostic only
+                print(f"Warning: Failed to collect {label} metadata: {metadata_error}")
+            else:
+                _datas.extend(metadata_entries)
+                if metadata_entries:
+                    print(f"Collected {len(metadata_entries)} {label} metadata files")
+
+        _extend_with_metadata("paddleocr", "PaddleOCR")
+        _extend_with_metadata("paddlepaddle", "PaddlePaddle")
+        _extend_with_metadata("paddlex", "PaddleX")
+
+    except Exception as e:
+        print(f"Warning: Data collection failed: {e}")
 
 # Hidden imports for PaddleOCR and dynamically loaded modules
 _hiddenimports = [


### PR DESCRIPTION
## Summary
- add a dedicated PyInstaller hook so paddlex/.version and related configs are bundled
- wire the hook into vlog-subs-tool.spec and add a paddlex hidden-import/data fallback
- document the required build flags for onefile/custom PyInstaller invocations

## Testing
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c4ffd6888327b90f6c9bcd2d6a3c